### PR TITLE
[FIX display] Swap inherit for display: contents

### DIFF
--- a/src/Media.tsx
+++ b/src/Media.tsx
@@ -409,7 +409,7 @@ export function createMedia<
           const generatedStyle: RenderPropStyleGenerator = matchingStyle => css`
             display: none;
             @media ${query} {
-              display: inherit;
+              display: contents;
               ${matchingStyle};
             }
           `


### PR DESCRIPTION
Swaps `display: inherit` with `display: contents` on visible elements, which removes the “container” and defers to the parent as if the element was never wrapped.