### PR TITLE
 [PATCH Media] Always output styled div.

### DIFF
--- a/src/DynamicResponsive.tsx
+++ b/src/DynamicResponsive.tsx
@@ -6,10 +6,6 @@
 
 import React from "react"
 
-const ResponsiveContext = React.createContext({})
-ResponsiveContext.Consumer.displayName = "Media.DynamicContext"
-ResponsiveContext.Provider.displayName = "Media.DynamicContext"
-
 /** TODO */
 export type MediaQueries<M extends string = string> = { [K in M]: string }
 
@@ -43,6 +39,10 @@ const shallowEqual = (a: MediaQueryMatches, b: MediaQueryMatches) => {
 
 /** TODO */
 export function createResponsiveComponents<M extends string>() {
+  const ResponsiveContext = React.createContext({})
+  ResponsiveContext.Consumer.displayName = "Media.DynamicContext"
+  ResponsiveContext.Provider.displayName = "Media.DynamicContext"
+
   const ResponsiveConsumer: React.SFC<
     React.ConsumerProps<MediaQueryMatches<M>>
   > = ResponsiveContext.Consumer as React.SFC<React.ConsumerProps<any>>

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -47,7 +47,7 @@ export function createBreakpointQueries(
   return Object.entries(atRanges).reduce(
     (queries, [k, v]) => ({
       ...queries,
-      [k]: createBreakpointQuery(breakpoints, sortedBreakpoints, v),
+      [k]: createBreakpointQuery(breakpoints, sortedBreakpoints, v)[1],
     }),
     {}
   )
@@ -60,7 +60,8 @@ export function createBreakpointQuery(
   sortedBreakpoints: string[],
   breakpointProps: MediaBreakpointProps<string>,
   onlyRenderAt?: string[]
-): string | null {
+): [boolean, string] {
+  let shouldRender = true
   // lessThan
   if (breakpointProps.lessThan) {
     const width = breakpoints[breakpointProps.lessThan]
@@ -70,10 +71,10 @@ export function createBreakpointQuery(
         ...onlyRenderAt.map(breakpoint => breakpoints[breakpoint])
       )
       if (lowestAllowedWidth >= width) {
-        return null
+        shouldRender = false
       }
     }
-    return `(max-width:${width - 1}px)`
+    return [shouldRender, `(max-width:${width - 1}px)`]
 
     // greaterThan
   } else if (breakpointProps.greaterThan) {
@@ -87,10 +88,10 @@ export function createBreakpointQuery(
         ...onlyRenderAt.map(breakpoint => breakpoints[breakpoint])
       )
       if (highestAllowedWidth < width) {
-        return null
+        shouldRender = false
       }
     }
-    return `(min-width:${width}px)`
+    return [shouldRender, `(min-width:${width}px)`]
 
     //  greaterThanOrEqual
   } else if (breakpointProps.greaterThanOrEqual) {
@@ -101,10 +102,10 @@ export function createBreakpointQuery(
         ...onlyRenderAt.map(breakpoint => breakpoints[breakpoint])
       )
       if (highestAllowedWidth < width) {
-        return null
+        shouldRender = false
       }
     }
-    return `(min-width:${width}px)`
+    return [shouldRender, `(min-width:${width}px)`]
 
     // between
   } else if (breakpointProps.between) {
@@ -122,12 +123,12 @@ export function createBreakpointQuery(
         Math.max(...allowedWidths) < fromWidth ||
         Math.min(...allowedWidths) >= toWidth
       ) {
-        return null
+        shouldRender = false
       }
     }
 
     // prettier-ignore
-    return `(min-width:${fromWidth}px) and (max-width:${toWidth - 1}px)`
+    return [shouldRender, `(min-width:${fromWidth}px) and (max-width:${toWidth - 1}px)`]
   }
   throw new Error(
     `Unexpected breakpoint props: ${JSON.stringify(breakpointProps)}`

--- a/src/__test__/Media.test.tsx
+++ b/src/__test__/Media.test.tsx
@@ -229,7 +229,10 @@ describe("Media", () => {
         </MediaContextProvider>
       )
       expect(
-        query.root.findAllByType("div").map(div => div.props.children)
+        query.root
+          .findAllByType("div")
+          .map(div => div.props.children)
+          .filter(Boolean)
       ).toEqual(["extra-small", "small"])
     })
 
@@ -242,7 +245,10 @@ describe("Media", () => {
         </MediaContextProvider>
       )
       expect(
-        query.root.findAllByType("div").map(div => div.props.children)
+        query.root
+          .findAllByType("div")
+          .map(div => div.props.children)
+          .filter(Boolean)
       ).toEqual(["small", "medium"])
     })
 
@@ -255,7 +261,10 @@ describe("Media", () => {
         </MediaContextProvider>
       )
       expect(
-        query.root.findAllByType("div").map(div => div.props.children)
+        query.root
+          .findAllByType("div")
+          .map(div => div.props.children)
+          .filter(Boolean)
       ).toEqual(["small", "medium"])
     })
 
@@ -268,7 +277,10 @@ describe("Media", () => {
         </MediaContextProvider>
       )
       expect(
-        query.root.findAllByType("div").map(div => div.props.children)
+        query.root
+          .findAllByType("div")
+          .map(div => div.props.children)
+          .filter(Boolean)
       ).toEqual(["small", "medium"])
     })
 
@@ -282,7 +294,10 @@ describe("Media", () => {
         </MediaContextProvider>
       )
       expect(
-        query.root.findAllByType("div").map(div => div.props.children)
+        query.root
+          .findAllByType("div")
+          .map(div => div.props.children)
+          .filter(Boolean)
       ).toEqual(["small - large"])
     })
 


### PR DESCRIPTION
Longer description in #19.

It seems like not always emitting this on the client leads to
styled-components re-using a class name that was generated during SSR
for a different Media instance.

I will iterate on this patch later on, but want this fix out first.