### PR TITLE
Automatically handle rendering of children

### DIFF
--- a/src/Media.tsx
+++ b/src/Media.tsx
@@ -11,10 +11,7 @@ import { intersection, propKey, createClassName } from "./Utils"
  *
  * @see {@link MediaProps.children}.
  */
-export type RenderProp = (
-  className: string,
-  renderChildren: boolean
-) => React.ReactNode
+export type RenderProp = (className: string) => React.ReactNode
 
 // TODO: All of these props should be mutually exclusive. Using a union should
 //       probably be made possible by https://github.com/Microsoft/TypeScript/pull/27408.
@@ -153,11 +150,6 @@ export interface MediaProps<B, I> extends MediaBreakpointProps<B> {
    * that receives the class-name it should use to have the media query styling
    * applied.
    *
-   * Additionally, the render prop receives a boolean that indicates wether or
-   * not its children should be rendered, which will be `false` if the media
-   * query is not included in the `onlyMatch` list. Use this flag if your
-   * component’s children may be expensive to render and you want to avoid any
-   * unnecessary work.
    * (@see {@link MediaContextProviderProps.onlyMatch} for details)
    *
    * @example
@@ -428,15 +420,18 @@ export function createMedia<
                 onlyMatch
               )
 
+            if (!renderChildren) {
+              return null
+            }
+
             if (props.children instanceof Function) {
-              return props.children(className, renderChildren)
+              return props.children(className)
             } else {
               return (
                 <div
                   className={`fresnel-container ${className} ${passedClassName}`}
-                  suppressHydrationWarning={!renderChildren}
                 >
-                  {renderChildren ? props.children : null}
+                  {props.children}
                 </div>
               )
             }

--- a/src/__test__/Media.test.tsx
+++ b/src/__test__/Media.test.tsx
@@ -251,19 +251,24 @@ describe("Media", () => {
       })
     })
 
-    it("yields wether or not the element’s children should be rendered", () => {
+    it("is not used when children should not be rendered", () => {
+      const renderSmall = jest.fn()
+      const renderMedium = jest.fn()
+
       const query = renderer.create(
         <MediaContextProvider onlyMatch={["extra-small", "small"]}>
-          <Media at="extra-small">
-            {(_, renderChildren) => (
-              <span>{renderChildren && "extra-small"}</span>
-            )}
-          </Media>
+          <Media at="extra-small">{() => <span>extra-small</span>}</Media>
           <Media at="small">
-            {(_, renderChildren) => <span>{renderChildren && "small"}</span>}
+            {() => {
+              renderSmall()
+              return <span>small</span>
+            }}
           </Media>
           <Media at="medium">
-            {(_, renderChildren) => <span>{renderChildren && "medium"}</span>}
+            {() => {
+              renderMedium()
+              return <span>medium</span>
+            }}
           </Media>
         </MediaContextProvider>
       )
@@ -273,6 +278,9 @@ describe("Media", () => {
           .map(div => div.props.children)
           .filter(Boolean)
       ).toEqual(["extra-small", "small"])
+
+      expect(renderSmall).toHaveBeenCalled()
+      expect(renderMedium).not.toHaveBeenCalled()
     })
   })
 
@@ -490,41 +498,6 @@ describe("Media", () => {
         expect(spy).not.toHaveBeenCalled()
         done()
       })
-    })
-
-    // This is the best we can do until we figure out a way to reproduce a
-    // warning, as per above.
-    it("does not warn about Media components that do not match and are empty", () => {
-      mockCurrentDynamicBreakpoint("medium")
-
-      const query = (renderer
-        .create(
-          <MediaContextProvider>
-            <Media at="extra-small">
-              <span className="extra-small" />
-            </Media>
-            <Media at="medium">
-              <span className="medium" />
-            </Media>
-            <Media at="large">
-              <span className="large" />
-            </Media>
-          </MediaContextProvider>
-        )
-        .toJSON() as any) as ReactTestRendererJSON[]
-
-      expect(
-        query.find(e => e.props.className.includes("extra-small")).props
-          .suppressHydrationWarning
-      ).toEqual(true)
-      expect(
-        query.find(e => e.props.className.includes("medium")).props
-          .suppressHydrationWarning
-      ).toEqual(false)
-      expect(
-        query.find(e => e.props.className.includes("large")).props
-          .suppressHydrationWarning
-      ).toEqual(true)
     })
   })
 

--- a/src/__test__/Media.test.tsx
+++ b/src/__test__/Media.test.tsx
@@ -358,6 +358,17 @@ describe("Media", () => {
       ).toEqual(["small - large"])
     })
 
+    it("is does not render unnecessary divs", () => {
+      const query = renderer.create(
+        <MediaContextProvider onlyMatch={["extra-small", "small"]}>
+          <Media at="extra-small">extra-small</Media>
+          <Media at="small">small</Media>
+          <Media at="medium">medium</Media>
+        </MediaContextProvider>
+      )
+      expect(query.root.findAllByType("div").length).toEqual(2)
+    })
+
     it("renders only matching interactions", () => {
       const query = renderer.create(
         <MediaContextProvider onlyMatch={["hover"]}>


### PR DESCRIPTION
It seems the default behavior is to render a wrapping div at breakpoints where we don't render children. I'm not sure why this is the default, since it only seems to bloat the resulting output w/ empty `div`s..

Please let me know if there's a reason to keep it around, potentially leveraging when `renderChildren` is false somehow (but that feels hacky) so I can update the docs/tests instead. Or I could tweak the API if this doesn't make sense for a breaking change, but I feel it simplifies it.