### PR TITLE
Allow style rules subsetting

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,8 +426,9 @@ export const HomePage = () => {
 Besides the `Media` and `MediaContextProvider` components, there's a
 `createMediaStyle` function that produces the CSS styling for all possible media
 queries that the `Media` instance can make use of while markup is being passed
-from the server to the client during hydration. Be sure to insert this within a
-`<style>` tag
+from the server to the client during hydration. If only a subset of breakpoint
+keys is used those can be optional specified as a parameter to minimize the
+output. Be sure to insert this within a `<style>` tag
 [in your document’s `<head>`](https://github.com/artsy/fresnel/blob/master/examples/ssr-rendering/src/server.tsx#L28).
 
 It’s advisable to do this setup in its own module so that it can be easily
@@ -446,7 +447,7 @@ const ExampleAppMedia = createMedia({
 })
 
 // Generate CSS to be injected into the head
-export const mediaStyle = ExampleAppMedia.createMediaStyle()
+export const mediaStyle = ExampleAppMedia.createMediaStyle() // optional: .createMediaStyle(['at'])
 export const { Media, MediaContextProvider } = ExampleAppMedia
 ```
 

--- a/src/Interactions.ts
+++ b/src/Interactions.ts
@@ -1,12 +1,16 @@
 import { createClassName, createRuleSet } from "./Utils"
 
+export enum InteractionKey {
+  interaction = "interaction",
+}
+
 /**
  * Encapsulates all interaction data needed by the Media component. The data is
  * generated on initialization so no further runtime work is necessary.
  */
 export class Interactions {
   static validKeys() {
-    return ["interaction"]
+    return [InteractionKey.interaction]
   }
 
   private _interactions: { [key: string]: string }
@@ -20,7 +24,10 @@ export class Interactions {
       (acc: string[], [name, query]) => {
         return [
           ...acc,
-          createRuleSet(createClassName("interaction", name), query),
+          createRuleSet(
+            createClassName(InteractionKey.interaction, name),
+            query
+          ),
         ]
       },
       []

--- a/src/Media.tsx
+++ b/src/Media.tsx
@@ -4,6 +4,7 @@ import React from "react"
 import { createResponsiveComponents } from "./DynamicResponsive"
 import { MediaQueries } from "./MediaQueries"
 import { intersection, propKey, createClassName } from "./Utils"
+import { BreakpointKey } from "./Breakpoints"
 
 /**
  * A render prop that can be used to render a different container element than
@@ -240,7 +241,7 @@ export interface CreateMediaResults<B, I> {
    * Generates a set of CSS rules that you should include in your application’s
    * styling to enable the hiding behaviour of your `Media` component uses.
    */
-  createMediaStyle(): string
+  createMediaStyle(breakpointKeys?: BreakpointKey[]): string
 
   /**
    * A list of your application’s breakpoints sorted from small to large.
@@ -458,7 +459,7 @@ export function createMedia<
   }
 }
 
-const MutuallyExclusiveProps = MediaQueries.validKeys()
+const MutuallyExclusiveProps: string[] = MediaQueries.validKeys()
 
 function validateProps(props) {
   const selectedProps = Object.keys(props).filter(prop =>

--- a/src/MediaQueries.ts
+++ b/src/MediaQueries.ts
@@ -1,4 +1,4 @@
-import { Breakpoints } from "./Breakpoints"
+import { Breakpoints, BreakpointKey } from "./Breakpoints"
 import { Interactions } from "./Interactions"
 import { intersection } from "./Utils"
 import { MediaBreakpointProps } from "./Media"
@@ -28,11 +28,11 @@ export class MediaQueries<B extends string> {
     return this._breakpoints
   }
 
-  public toStyle = () => {
+  public toStyle = (breakpointKeys?: BreakpointKey[]) => {
     return [
       // Don’t add any size to the layout
       ".fresnel-container{margin:0;padding:0;}",
-      ...this._breakpoints.toRuleSets(),
+      ...this._breakpoints.toRuleSets(breakpointKeys),
       ...this._interactions.toRuleSets(),
     ].join("\n")
   }

--- a/src/__test__/Media.test.tsx
+++ b/src/__test__/Media.test.tsx
@@ -4,6 +4,7 @@ import React from "react"
 import renderer, { ReactTestRendererJSON } from "react-test-renderer"
 import { injectGlobal } from "styled-components"
 import { createMedia } from "../Media"
+import { BreakpointKey } from "../Breakpoints"
 import { MediaQueries } from "../MediaQueries"
 import ReactDOMServer from "react-dom/server"
 import ReactDOM from "react-dom"
@@ -144,6 +145,18 @@ describe("Media", () => {
         )
         .toJSON()
       expect(query.props.className).toContain("foo")
+    })
+
+    it("includes only style rules for specified breakpoint keys", () => {
+      const defaultMediaStyles = createMediaStyle()
+      expect(defaultMediaStyles).toContain(".fresnel-between-small-large")
+
+      const subsetMediaStyles = createMediaStyle([
+        BreakpointKey.at,
+        BreakpointKey.greaterThan,
+      ])
+      expect(subsetMediaStyles).not.toContain(".fresnel-between-small-large")
+      expect(subsetMediaStyles).toContain(".fresnel-at-extra-small")
     })
   })
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,1 +1,2 @@
 export { createMedia } from "./Media"
+export { BreakpointKey } from "./Breakpoints"


### PR DESCRIPTION
# Pull Request

Currently the output of `.createMediaStyle()` includes all style rules that are possible based on the breakpoint keys. Even if just some are used in a codebase it always results in the same string. While it might not be much it's an overhead that can be avoided by allowing developers to specify a potential subset.

For better referencing the supported breakpoint keys the entries [were defined and exported as an enum](https://github.com/artsy/fresnel/compare/master...Autarc:feat/allow-style-rules-subset?expand=1#diff-c140c1c5c10a63b58a7495d37570cbb1R17). 