### PR TITLE
Fix missing comma in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ You would then produce the set of media components like so:
 const ExampleAppMedia = createMedia({
   breakpoints: {
     sm: 0,
-    md: 768
+    md: 768,
     lg: 1024,
     xl: 1192,
   },


### PR DESCRIPTION
Noticed a missing comma when using one of the examples from README. Pretty irrelevant but hey, thought I'd PR it anyways.