### PR TITLE
Correct orientation interaction docs and add usage examples to ssr demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,8 +348,8 @@ const ExampleAppMedia = createMedia({
   interactions: {
     hover: "(hover: hover)",
     notHover: "(hover: none)",
-    landscape: "(orientation: landscape)",
-    portrait: "(orientation: portrait)",
+    landscape: "not all and (orientation: landscape)",
+    portrait: "not all and (orientation: portrait)",
   },
 })
 

--- a/examples/ssr-rendering/src/App.tsx
+++ b/examples/ssr-rendering/src/App.tsx
@@ -4,6 +4,16 @@ import { Media, MediaContextProvider } from "./Media"
 export const App = () => {
   return (
     <MediaContextProvider>
+      <Media interaction="hover">
+        media has hover interaction capabilities
+      </Media>
+      <Media interaction="notHover">
+        media lacks hover interaction capabilities
+      </Media>
+
+      <Media interaction="landscape">landscape</Media>
+      <Media interaction="portrait">portrait</Media>
+
       <Media at="sm">Hello mobile!</Media>
       <Media greaterThan="sm">Hello desktop!</Media>
     </MediaContextProvider>

--- a/examples/ssr-rendering/src/Media.tsx
+++ b/examples/ssr-rendering/src/Media.tsx
@@ -1,6 +1,12 @@
 import { createMedia } from "@artsy/fresnel"
 
 const ExampleAppMedia = createMedia({
+  interactions: {
+    landscape: "not all and (orientation: landscape)",
+    portrait: "not all and (orientation: portrait)",
+    hover: "(hover: hover)",
+    notHover: "(hover: none)",
+  },
   breakpoints: {
     sm: 0,
     md: 768,


### PR DESCRIPTION
This is a small start to help correct some of the documentation we had around orientation interactions. Specifically prepending `not all and` is an important addition to ensure the negation of other potential orientation matches. 

We'll follow up with #153 to improve the docs further.