### PR TITLE
Expand generic type names to be more descriptive

### DIFF
--- a/src/MediaQueries.ts
+++ b/src/MediaQueries.ts
@@ -1,4 +1,4 @@
-import { Breakpoints, BreakpointKey } from "./Breakpoints"
+import { Breakpoints, BreakpointConstraint } from "./Breakpoints"
 import { Interactions } from "./Interactions"
 import { intersection } from "./Utils"
 import { MediaBreakpointProps } from "./Media"
@@ -28,7 +28,7 @@ export class MediaQueries<B extends string> {
     return this._breakpoints
   }
 
-  public toStyle = (breakpointKeys?: BreakpointKey[]) => {
+  public toStyle = (breakpointKeys?: BreakpointConstraint[]) => {
     return [
       // Don’t add any size to the layout
       ".fresnel-container{margin:0;padding:0;}",

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,11 +1,11 @@
 import { MediaBreakpointProps } from "./Media"
-import { MediaBreakpointKey } from "./Breakpoints"
+import { BreakpointConstraintKey } from "./Breakpoints"
 
 /**
  * Extracts the single breakpoint prop from the props object.
  */
 export function propKey(breakpointProps: MediaBreakpointProps) {
-  return Object.keys(breakpointProps)[0] as MediaBreakpointKey
+  return Object.keys(breakpointProps)[0] as BreakpointConstraintKey
 }
 
 /**

--- a/src/__test__/Media.test.tsx
+++ b/src/__test__/Media.test.tsx
@@ -4,7 +4,7 @@ import React from "react"
 import renderer, { ReactTestRendererJSON } from "react-test-renderer"
 import { injectGlobal } from "styled-components"
 import { createMedia } from "../Media"
-import { BreakpointKey } from "../Breakpoints"
+import { BreakpointConstraint } from "../Breakpoints"
 import { MediaQueries } from "../MediaQueries"
 import ReactDOMServer from "react-dom/server"
 import ReactDOM from "react-dom"
@@ -152,8 +152,8 @@ describe("Media", () => {
       expect(defaultMediaStyles).toContain(".fresnel-between-small-large")
 
       const subsetMediaStyles = createMediaStyle([
-        BreakpointKey.at,
-        BreakpointKey.greaterThan,
+        BreakpointConstraint.at,
+        BreakpointConstraint.greaterThan,
       ])
       expect(subsetMediaStyles).not.toContain(".fresnel-between-small-large")
       expect(subsetMediaStyles).toContain(".fresnel-at-extra-small")

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,2 +1,2 @@
 export { createMedia } from "./Media"
-export { BreakpointKey } from "./Breakpoints"
+export { BreakpointConstraint as BreakpointKey } from "./Breakpoints"


### PR DESCRIPTION
This is a quality of life refactor to ease understanding of what types represent what. It expends generic template names like `B` to be a more descriptive `BreakpointKey`. 

There are a few particular places that deserve special attention which I'll call out in the changes. 

## Release Notes

This update expands the generic type names to be self descriptive instead of being single characters. While this change predominately only affects internal types the internal `BreakpointKey` was renamed to `BreakpointConstraint`. Give that that's not documented as part of our external API we haven't listed this release as a breaking change; however, if you use that import you _will_ need to update your references. 