### PR TITLE
Prevent unnecessary nesting of breakpoint nodes (fixes #132)

### DIFF
--- a/src/Breakpoints.ts
+++ b/src/Breakpoints.ts
@@ -134,6 +134,39 @@ export class Breakpoints<BreakpointKey extends string> {
     }) as BreakpointKey | undefined
   }
 
+  public toVisibleAtBreakpointSet(breakpointProps: MediaBreakpointProps) {
+    breakpointProps = this._normalizeProps(breakpointProps)
+    if (breakpointProps.lessThan) {
+      const breakpointIndex = this.sortedBreakpoints.findIndex(
+        bp => bp === breakpointProps.lessThan
+      )
+      return this.sortedBreakpoints.slice(0, breakpointIndex)
+    } else if (breakpointProps.greaterThan) {
+      const breakpointIndex = this.sortedBreakpoints.findIndex(
+        bp => bp === breakpointProps.greaterThan
+      )
+      return this.sortedBreakpoints.slice(breakpointIndex + 1)
+    } else if (breakpointProps.greaterThanOrEqual) {
+      const breakpointIndex = this.sortedBreakpoints.findIndex(
+        bp => bp === breakpointProps.greaterThanOrEqual
+      )
+      return this.sortedBreakpoints.slice(breakpointIndex)
+    } else if (breakpointProps.between) {
+      const between = breakpointProps.between
+      const fromBreakpointIndex = this.sortedBreakpoints.findIndex(
+        bp => bp === between[0]
+      )
+      const toBreakpointIndex = this.sortedBreakpoints.findIndex(
+        bp => bp === between[1]
+      )
+      return this.sortedBreakpoints.slice(
+        fromBreakpointIndex,
+        toBreakpointIndex
+      )
+    }
+    return []
+  }
+
   public toRuleSets(keys = Breakpoints.validKeys()) {
     const selectedMediaQueries = keys.reduce(
       (mediaQueries, query) => {

--- a/src/__test__/Breakpoints.test.tsx
+++ b/src/__test__/Breakpoints.test.tsx
@@ -1,0 +1,43 @@
+import { Breakpoints } from "../Breakpoints"
+
+const config = {
+  "extra-small": 0,
+  small: 768,
+  medium: 1024,
+  large: 1120,
+}
+
+const breakpoint = new Breakpoints(config)
+
+describe("Breakpoints", () => {
+  describe.only("toVisibleAtBreakpointSet", () => {
+    it("returns correct values for greaterThan", () => {
+      const breakpoints = breakpoint.toVisibleAtBreakpointSet({
+        greaterThan: "small",
+      })
+      expect(breakpoints).toEqual(["medium", "large"])
+    })
+    it("returns correct values for greaterThanOrEqual", () => {
+      const breakpoints = breakpoint.toVisibleAtBreakpointSet({
+        greaterThanOrEqual: "small",
+      })
+      expect(breakpoints).toEqual(["small", "medium", "large"])
+    })
+    it("returns correct values for lessThan", () => {
+      const breakpoints = breakpoint.toVisibleAtBreakpointSet({
+        lessThan: "small",
+      })
+      expect(breakpoints).toEqual(["extra-small"])
+    })
+    it("returns correct values for at", () => {
+      const breakpoints = breakpoint.toVisibleAtBreakpointSet({ at: "small" })
+      expect(breakpoints).toEqual(["small"])
+    })
+    it("returns correct values for between", () => {
+      const breakpoints = breakpoint.toVisibleAtBreakpointSet({
+        between: ["extra-small", "medium"],
+      })
+      expect(breakpoints).toEqual(["extra-small", "small"])
+    })
+  })
+})

--- a/src/__test__/Breakpoints.test.tsx
+++ b/src/__test__/Breakpoints.test.tsx
@@ -10,7 +10,7 @@ const config = {
 const breakpoint = new Breakpoints(config)
 
 describe("Breakpoints", () => {
-  describe.only("toVisibleAtBreakpointSet", () => {
+  describe("toVisibleAtBreakpointSet", () => {
     it("returns correct values for greaterThan", () => {
       const breakpoints = breakpoint.toVisibleAtBreakpointSet({
         greaterThan: "small",

--- a/src/__test__/Media.test.tsx
+++ b/src/__test__/Media.test.tsx
@@ -705,7 +705,7 @@ describe("Media", () => {
       expect(query.root.findAllByType("span", { deep: true }).length).toBe(1)
     })
 
-    it("renders correct Media when using lessThan prop", () => {
+    it("renders correct Media when using between prop", () => {
       const query = renderer.create(
         <MediaContextProvider>
           <Media between={["small", "large"]}>

--- a/src/__test__/Media.test.tsx
+++ b/src/__test__/Media.test.tsx
@@ -534,10 +534,6 @@ describe("Media", () => {
     it("only renders one element when Media is nested within Media", () => {
       const query = renderer.create(
         <MediaContextProvider>
-          <Media at="extra-small">
-            <span className="extra-small" />
-          </Media>
-
           <Media at="medium">
             <Media at="extra-small">
               <span className="extra-small" />
@@ -549,20 +545,16 @@ describe("Media", () => {
               <span className="large" />
             </Media>
           </Media>
-
-          <Media at="large">
-            <span className="large" />
-          </Media>
         </MediaContextProvider>
       )
 
       expect(
         query.root.findAllByProps({ className: "extra-small" }, { deep: true })
           .length
-      ).toBe(1)
+      ).toBe(0)
       expect(
         query.root.findAllByProps({ className: "large" }, { deep: true }).length
-      ).toBe(1)
+      ).toBe(0)
       expect(
         query.root.findAllByProps({ className: "medium" }, { deep: true })
           .length

--- a/src/__test__/Media.test.tsx
+++ b/src/__test__/Media.test.tsx
@@ -568,6 +568,169 @@ describe("Media", () => {
           .length
       ).toBe(1)
     })
+
+    it("renders no spans with deep nesting where parent has no intersection with children", () => {
+      const query = renderer.create(
+        <MediaContextProvider>
+          <Media at="extra-small">
+            <Media at="medium">
+              <Media at="extra-small">
+                <span className="extra-small" />
+              </Media>
+              <Media at="medium">
+                <span className="medium" />
+              </Media>
+              <Media at="large">
+                <span className="large" />
+              </Media>
+            </Media>
+
+            <Media at="large">
+              <span className="large" />
+            </Media>
+          </Media>
+        </MediaContextProvider>
+      )
+
+      expect(query.root.findAllByType("span", { deep: true }).length).toBe(0)
+    })
+
+    it("renders multiple spans in path, without rendering spans that don't intersect", () => {
+      const query = renderer.create(
+        <MediaContextProvider>
+          <Media at="extra-small">
+            {/* Should render */}
+            <span />
+            <Media at="extra-small">
+              {/* Should render */}
+              <span />
+              <Media at="extra-small">
+                {/* Should render */}
+                <span />
+              </Media>
+              <Media at="medium">
+                {/* Should NOT render */}
+                <span />
+              </Media>
+            </Media>
+            <Media at="medium">
+              {/* Should NOT render */}
+              <span />
+            </Media>
+          </Media>
+        </MediaContextProvider>
+      )
+
+      expect(query.root.findAllByType("span", { deep: true }).length).toBe(3)
+    })
+
+    it("renders correct Media when using greaterThan prop", () => {
+      const query = renderer.create(
+        <MediaContextProvider>
+          <Media greaterThan="small">
+            <Media at="extra-small">
+              {/* Should NOT render */}
+              <span />
+            </Media>
+            <Media at="small">
+              {/* Should NOT render */}
+              <span />
+            </Media>
+            <Media at="medium">
+              {/* Should render */}
+              <span />
+            </Media>
+            <Media at="large">
+              {/* Should render */}
+              <span />
+            </Media>
+          </Media>
+        </MediaContextProvider>
+      )
+
+      expect(query.root.findAllByType("span", { deep: true }).length).toBe(2)
+    })
+
+    it("renders correct Media when using greaterThanOrEqual prop", () => {
+      const query = renderer.create(
+        <MediaContextProvider>
+          <Media greaterThanOrEqual="small">
+            <Media at="extra-small">
+              {/* Should NOT render */}
+              <span />
+            </Media>
+            <Media at="small">
+              {/* Should render */}
+              <span />
+            </Media>
+            <Media at="medium">
+              {/* Should render */}
+              <span />
+            </Media>
+            <Media at="large">
+              {/* Should render */}
+              <span />
+            </Media>
+          </Media>
+        </MediaContextProvider>
+      )
+
+      expect(query.root.findAllByType("span", { deep: true }).length).toBe(3)
+    })
+
+    it("renders correct Media when using lessThan prop", () => {
+      const query = renderer.create(
+        <MediaContextProvider>
+          <Media lessThan="small">
+            <Media at="extra-small">
+              {/* Should render */}
+              <span />
+            </Media>
+            <Media at="small">
+              {/* Should NOT render */}
+              <span />
+            </Media>
+            <Media at="medium">
+              {/* Should NOT render */}
+              <span />
+            </Media>
+            <Media at="large">
+              {/* Should NOT render */}
+              <span />
+            </Media>
+          </Media>
+        </MediaContextProvider>
+      )
+
+      expect(query.root.findAllByType("span", { deep: true }).length).toBe(1)
+    })
+
+    it("renders correct Media when using lessThan prop", () => {
+      const query = renderer.create(
+        <MediaContextProvider>
+          <Media between={["small", "large"]}>
+            <Media at="extra-small">
+              {/* Should NOT render */}
+              <span />
+            </Media>
+            <Media at="small">
+              {/* Should render */}
+              <span />
+            </Media>
+            <Media at="medium">
+              {/* Should render */}
+              <span />
+            </Media>
+            <Media at="large">
+              {/* Should NOT render */}
+              <span />
+            </Media>
+          </Media>
+        </MediaContextProvider>
+      )
+
+      expect(query.root.findAllByType("span", { deep: true }).length).toBe(2)
+    })
   })
 
   // TODO: This actually doesn’t make sense, I think, because if the user

--- a/src/__test__/Media.test.tsx
+++ b/src/__test__/Media.test.tsx
@@ -530,6 +530,46 @@ describe("Media", () => {
     })
   })
 
+  describe("prevent nested unnecessary renders", () => {
+    it("only renders one element when Media is nested within Media", () => {
+      const query = renderer.create(
+        <MediaContextProvider>
+          <Media at="extra-small">
+            <span className="extra-small" />
+          </Media>
+
+          <Media at="medium">
+            <Media at="extra-small">
+              <span className="extra-small" />
+            </Media>
+            <Media at="medium">
+              <span className="medium" />
+            </Media>
+            <Media at="large">
+              <span className="large" />
+            </Media>
+          </Media>
+
+          <Media at="large">
+            <span className="large" />
+          </Media>
+        </MediaContextProvider>
+      )
+
+      expect(
+        query.root.findAllByProps({ className: "extra-small" }, { deep: true })
+          .length
+      ).toBe(1)
+      expect(
+        query.root.findAllByProps({ className: "large" }, { deep: true }).length
+      ).toBe(1)
+      expect(
+        query.root.findAllByProps({ className: "medium" }, { deep: true })
+          .length
+      ).toBe(1)
+    })
+  })
+
   // TODO: This actually doesn’t make sense, I think, because if the user
   //       decides to not use a provider they are opting for rendering all
   //       variants. We just need to make sure to document this well.


### PR DESCRIPTION
This PR introduces a mechanism that prevents children of `Media` from ever rendering if there is no possible way of them rendering - hopefully, a fix for #132. We recently refactored an app to use this library and noticed that the amount of duplicated nodes being rendered was causing performance downside.

Example:
```tsx
<Media at="sm">
  <Media at="sm">
    <Media at="sm">
      <img src="base64:mymassssiveimage" />
    </Media>
    <Media at="md">
      <img src="base64:mymassssiveimage" />
    </Media>
  </Media>
  <Media at="md">
    <Media at="sm">
      <img src="base64:mymassssiveimage" />
    </Media>
    <Media at="md">
      <img src="base64:mymassssiveimage" />
    </Media>
  </Media>
</Media>
```

This would result in the server returning 4 of the large `<img />` strings, where we could logically just return 1, given the parent at the root of the tree is an `sm`. The output should ideally be:

```tsx
<div class="fresnel-container fresnel-at-sm">
  <div class="fresnel-container fresnel-at-sm">
    <div class="fresnel-container fresnel-at-sm"><img src="base64:mymassssiveimage" /></div>
  </div>
</div>
```

The update works using context and by wrapping each `Media` in a `Provider`, the child `Media`'s can then check to see whether there are any conflicting parents that would prevent it from rendering in the first place.

We'll install this fork in our project and I'll shift this out of draft once we are confident it's working.