### PR TITLE
fix typo in Readme: mediaClassNames → className

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,9 +409,9 @@ export const HomePage = () => {
     <>
       <Media at="sm">Hello mobile!</Media>
       <Media greaterThan="sm">
-        {(mediaClassNames, renderChildren) => {
+        {(className, renderChildren) => {
           return (
-            <MySpecialComponent className={mediaClassNames}>
+            <MySpecialComponent className={className}>
               {renderChildren ? "Hello desktop!" : null}
             </MySpecialComponent>
           )

--- a/README.md
+++ b/README.md
@@ -610,10 +610,10 @@ a `matchMedia` example.)
 ```tsx
 <>
   <Media at="sm">
-    {this.getComponent('sm')
+    {this.getComponent('sm')}
   </Media>
   <Media greaterThan="sm">
-    {this.getComponent()
+    {this.getComponent()}
   </Media>
 </>
 ```


### PR DESCRIPTION
Since className is what is used: https://github.com/artsy/fresnel/blob/fa0ff2920a14bad9f33a7f3b687fc3318a5e1fa4/src/Media.tsx#L16