### PR TITLE
Adjust max-width breakpoints to account for fractional pixels

### DIFF
--- a/src/Breakpoints.ts
+++ b/src/Breakpoints.ts
@@ -290,7 +290,7 @@ export class Breakpoints<BreakpointKey extends string> {
     breakpointProps = this._normalizeProps(breakpointProps)
     if (breakpointProps.lessThan) {
       const width = this._breakpoints[breakpointProps.lessThan]
-      return `(max-width:${width - 1}px)`
+      return `(max-width:${width - 0.02}px)`
     } else if (breakpointProps.greaterThan) {
       const width = this._breakpoints[
         this._findNextBreakpoint(breakpointProps.greaterThan)
@@ -305,7 +305,7 @@ export class Breakpoints<BreakpointKey extends string> {
       //       to add `outside`.
       const fromWidth = this._breakpoints[breakpointProps.between[0]]
       const toWidth = this._breakpoints[breakpointProps.between[1]]
-      return `(min-width:${fromWidth}px) and (max-width:${toWidth - 1}px)`
+      return `(min-width:${fromWidth}px) and (max-width:${toWidth - 0.02}px)`
     }
     throw new Error(
       `Unexpected breakpoint props: ${JSON.stringify(breakpointProps)}`

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -55,7 +55,7 @@ export function castBreakpointsToIntegers(breakpoints: {
   return keys.reduce(
     (previous, current, currentIndex) => ({
       ...previous,
-      [keys[currentIndex]]: Number(breakpoints[current]),
+      [keys[currentIndex]]: Math.round(Number(breakpoints[current])),
     }),
     {}
   )


### PR DESCRIPTION
Fixes [issue 208](https://github.com/artsy/fresnel/issues/208) where window widths with fractional pixels cause no content to be rendered when between breakpoints.

I rounded breakpoints to ensure they are always integers, and used a 0.02px delta for the max-width queries. This accounts for the webkit bug where any smaller of a delta gets rounded up ([see here](https://bugs.webkit.org/show_bug.cgi?id=178261)).