### PR TITLE
Unit test update for fractional pixels

### DIFF
--- a/src/__test__/Media.test.tsx
+++ b/src/__test__/Media.test.tsx
@@ -167,7 +167,7 @@ describe("Media", () => {
         .toJSON()
       expect(query.type).toEqual("div")
       expect(query).toHaveStyleRule("display", "none!important", {
-        media: "not all and (max-width:767px)",
+        media: "not all and (max-width:767.98px)",
       })
     })
 
@@ -197,7 +197,7 @@ describe("Media", () => {
         .toJSON()
       expect(query.type).toEqual("div")
       expect(query).toHaveStyleRule("display", "none!important", {
-        media: "not all and (min-width:768px) and (max-width:1119px)",
+        media: "not all and (min-width:768px) and (max-width:1119.98px)",
       })
     })
 
@@ -260,7 +260,7 @@ describe("Media", () => {
         .toJSON()
       expect(query.type).toEqual("span")
       expect(query).toHaveStyleRule("display", "none!important", {
-        media: "not all and (max-width:767px)",
+        media: "not all and (max-width:767.98px)",
       })
     })
 


### PR DESCRIPTION
Fixed failing test to account for new max-width media query value being 0.02px less than the breakpoint.