### PR TITLE
feat(react-18): Add official React 18 SSR support

### DIFF
--- a/examples/nextjs/src/components/Articles.tsx
+++ b/examples/nextjs/src/components/Articles.tsx
@@ -1,0 +1,18 @@
+import { getAPI } from "../utils/api"
+
+const api = getAPI()
+
+export const Articles = () => {
+  const { data } = api.fetchArticles.read()
+
+  return (
+    <div>
+      <h2>Featured Articles</h2>
+      <ul>
+        {data.articles.map((article) => {
+          return <li key={article.title}>{article.title}</li>
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/examples/nextjs/src/components/Artists.tsx
+++ b/examples/nextjs/src/components/Artists.tsx
@@ -1,0 +1,18 @@
+import { getAPI } from "../utils/api"
+
+const api = getAPI()
+
+export const Artists = () => {
+  const { data } = api.fetchArtists.read()
+
+  return (
+    <div>
+      <h2>Trending Artists</h2>
+      <ul>
+        {data.artists.map((artist) => {
+          return <li key={artist.name}>{artist.name}</li>
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/examples/nextjs/src/components/Desktop.tsx
+++ b/examples/nextjs/src/components/Desktop.tsx
@@ -1,7 +1,9 @@
-import { useEffect } from "react"
+import { Suspense, useEffect } from "react"
+import { Artists } from "./Artists"
 
 export const Desktop = () => {
   useEffect(() => {
+    // tslint:disable-next-line:no-console
     console.log("firing desktop")
   }, [])
 

--- a/examples/nextjs/src/components/Desktop.tsx
+++ b/examples/nextjs/src/components/Desktop.tsx
@@ -1,0 +1,13 @@
+import { useEffect } from "react"
+
+export const Desktop = () => {
+  useEffect(() => {
+    console.log("firing desktop")
+  }, [])
+
+  return (
+    <div>
+      <h1>Desktop</h1>
+    </div>
+  )
+}

--- a/examples/nextjs/src/components/Mobile.tsx
+++ b/examples/nextjs/src/components/Mobile.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react"
 
 export const Mobile = () => {
   useEffect(() => {
+    // tslint:disable-next-line:no-console
     console.log("firing mobile")
   }, [])
 

--- a/examples/nextjs/src/components/Mobile.tsx
+++ b/examples/nextjs/src/components/Mobile.tsx
@@ -1,0 +1,13 @@
+import { useEffect } from "react"
+
+export const Mobile = () => {
+  useEffect(() => {
+    console.log("firing mobile")
+  }, [])
+
+  return (
+    <div>
+      <h1>Mobile</h1>
+    </div>
+  )
+}

--- a/examples/nextjs/src/pages/index.tsx
+++ b/examples/nextjs/src/pages/index.tsx
@@ -1,10 +1,45 @@
+import { SuspenseWrapper } from "../../../../dist/suspense/SuspenseWrapper"
+import { Desktop } from "../components/Desktop"
+import { Mobile } from "../components/Mobile"
 import { Media, MediaContextProvider } from "../media"
 
 export default function HomePage() {
   return (
-    <MediaContextProvider disableDynamicMediaQueries>
-      <Media at="xs">Hello mobile!</Media>
-      <Media greaterThan="xs">Hello desktop!</Media>
+    <MediaContextProvider>
+      <Media at="xs">
+        {(className, renderChildren, isPending) => {
+          return (
+            <SuspenseWrapper
+              media={{
+                active: renderChildren,
+                isPending,
+              }}
+            >
+              <div className={className}>
+                <Mobile />
+              </div>
+            </SuspenseWrapper>
+          )
+        }}
+      </Media>
+      <Media greaterThan="xs">
+        {(className, renderChildren, isPending) => {
+          return (
+            <SuspenseWrapper
+              media={{
+                active: renderChildren,
+                isPending,
+              }}
+            >
+              <div className={className}>
+                <Desktop />
+              </div>
+            </SuspenseWrapper>
+          )
+        }}
+      </Media>
+      {/* <Media at="xs">Hello mobile!</Media>
+      <Media greaterThan="xs">Hello desktop!</Media> */}
     </MediaContextProvider>
   )
 }

--- a/examples/nextjs/src/pages/index.tsx
+++ b/examples/nextjs/src/pages/index.tsx
@@ -1,45 +1,29 @@
-import { SuspenseWrapper } from "../../../../dist/suspense/SuspenseWrapper"
+import { Suspense } from "react"
+import { Articles } from "../components/Articles"
+import { Artists } from "../components/Artists"
 import { Desktop } from "../components/Desktop"
 import { Mobile } from "../components/Mobile"
 import { Media, MediaContextProvider } from "../media"
 
 export default function HomePage() {
   return (
-    <MediaContextProvider>
-      <Media at="xs">
-        {(className, renderChildren, isPending) => {
-          return (
-            <SuspenseWrapper
-              media={{
-                active: renderChildren,
-                isPending,
-              }}
-            >
-              <div className={className}>
-                <Mobile />
-              </div>
-            </SuspenseWrapper>
-          )
-        }}
-      </Media>
-      <Media greaterThan="xs">
-        {(className, renderChildren, isPending) => {
-          return (
-            <SuspenseWrapper
-              media={{
-                active: renderChildren,
-                isPending,
-              }}
-            >
-              <div className={className}>
-                <Desktop />
-              </div>
-            </SuspenseWrapper>
-          )
-        }}
-      </Media>
-      {/* <Media at="xs">Hello mobile!</Media>
-      <Media greaterThan="xs">Hello desktop!</Media> */}
-    </MediaContextProvider>
+    <>
+      <MediaContextProvider>
+        <Media at="xs">
+          <Mobile />
+
+          <Suspense fallback={<div>Loading articles...</div>}>
+            <Articles />
+          </Suspense>
+        </Media>
+        <Media greaterThan="xs">
+          <Desktop />
+
+          <Suspense fallback={<div>Loading artists...</div>}>
+            <Artists />
+          </Suspense>
+        </Media>
+      </MediaContextProvider>
+    </>
   )
 }

--- a/examples/nextjs/src/utils/api.ts
+++ b/examples/nextjs/src/utils/api.ts
@@ -1,0 +1,27 @@
+import { suspensePromise } from "../utils/suspensePromise"
+
+// Create a simple suspense-friendly API
+export const getAPI = () => {
+  return {
+    fetchArtists: suspensePromise(() => {
+      return fetch(
+        "https://deelay.me/2000/https://metaphysics-staging.artsy.net/v2?query={ artists(sort: TRENDING_DESC) { name } }"
+      )
+        .then((response) => response.json())
+        .catch((error) => {
+          // tslint:disable-next-line:no-console
+          console.error(error)
+        })
+    }),
+    fetchArticles: suspensePromise(() => {
+      return fetch(
+        "https://deelay.me/2000/https://metaphysics-staging.artsy.net/v2?query={ articles(featured: true) { title } }"
+      )
+        .then((response) => response.json())
+        .catch((error) => {
+          // tslint:disable-next-line:no-console
+          console.error(error)
+        })
+    }),
+  }
+}

--- a/examples/nextjs/src/utils/suspensePromise.ts
+++ b/examples/nextjs/src/utils/suspensePromise.ts
@@ -1,0 +1,28 @@
+/**
+ * Promise wrapper to support React 18's suspense
+ */
+export const suspensePromise = (promise) => {
+  let status = "pending"
+  let result
+  const suspend = promise().then(
+    (res) => {
+      status = "success"
+      result = res
+    },
+    (err) => {
+      status = "error"
+      result = err
+    }
+  )
+  return {
+    read: () => {
+      if (status === "pending") {
+        throw suspend
+      } else if (status === "error") {
+        throw result
+      } else if (status === "success") {
+        return result
+      }
+    },
+  }
+}

--- a/examples/ssr-rendering/src/App.tsx
+++ b/examples/ssr-rendering/src/App.tsx
@@ -4,7 +4,7 @@ import { Media, MediaContextProvider } from "./Media"
 
 export const App = () => {
   return (
-    <MediaContextProvider disableDynamicMediaQueries>
+    <MediaContextProvider>
       <Media interaction="landscape">landscape</Media>
       <Media interaction="portrait">portrait</Media>
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "jest": "24.9.0",
     "jest-styled-components": "6.2.2",
     "lint-staged": "7.3.0",
-    "prettier": "1.17.1",
+    "prettier": "^2.7.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-test-renderer": "^18.2.0",

--- a/src/DynamicResponsive.tsx
+++ b/src/DynamicResponsive.tsx
@@ -6,11 +6,6 @@ import React, {
   useTransition,
 } from "react"
 
-/**
- * TODO: This is the deprecated runtime media-query component from Reaction.
- *       It can probably be simplified somewhat if we’re not going to be using
- *       it directly any longer.
- */
 /** TODO */
 export type MediaQueries<M extends string = string> = { [K in M]: string }
 
@@ -115,20 +110,20 @@ export function createResponsiveComponents<M extends string>() {
     const [isPending, startTransition] = useTransition()
 
     const [mediaQueryMatchers] = useState(() => {
-      let mediaQueryMatchers: MediaQueryMatchers | undefined = undefined
+      let _mediaQueryMatchers: MediaQueryMatchers | undefined = undefined
 
       if (isSupportedEnvironment() && mediaQueries != null) {
-        mediaQueryMatchers = setupMatchers(mediaQueries)
+        _mediaQueryMatchers = setupMatchers(mediaQueries)
       }
-      return mediaQueryMatchers
+      return _mediaQueryMatchers
     })
 
     const [mediaQueryMatches, setMediaQueryMatches] = useState(() => {
-      let mediaQueryMatches: MediaQueryMatches
+      let _mediaQueryMatches: MediaQueryMatches
       if (isSupportedEnvironment() && mediaQueryMatchers != null) {
-        mediaQueryMatches = checkMatchers(mediaQueryMatchers)
+        _mediaQueryMatches = checkMatchers(mediaQueryMatchers)
       } else {
-        mediaQueryMatches = Object.keys(mediaQueries).reduce(
+        _mediaQueryMatches = Object.keys(mediaQueries).reduce(
           (matches, key) => ({
             ...matches,
             [key]:
@@ -138,7 +133,7 @@ export function createResponsiveComponents<M extends string>() {
           {}
         )
       }
-      return mediaQueryMatches
+      return _mediaQueryMatches
     })
 
     /**
@@ -146,23 +141,23 @@ export function createResponsiveComponents<M extends string>() {
      */
     const mediaQueryStatusChangedCallback = useCallback(() => {
       if (isSupportedEnvironment() && mediaQueryMatchers) {
-        const mediaQueryMatches = checkMatchers(mediaQueryMatchers)
+        const _mediaQueryMatches = checkMatchers(mediaQueryMatchers)
         startTransition(() => {
-          setMediaQueryMatches(mediaQueryMatches)
+          setMediaQueryMatches(_mediaQueryMatches)
         })
       }
     }, [mediaQueryMatchers])
 
     useEffect(() => {
       if (mediaQueryMatchers) {
-        Object.values(mediaQueryMatchers).forEach((matcher) => {
+        Object.values(mediaQueryMatchers).forEach(matcher => {
           matcher.addEventListener("change", mediaQueryStatusChangedCallback)
         })
       }
 
       return () => {
         if (mediaQueryMatchers) {
-          Object.values(mediaQueryMatchers).forEach((matcher) =>
+          Object.values(mediaQueryMatchers).forEach(matcher =>
             matcher.removeEventListener(
               "change",
               mediaQueryStatusChangedCallback

--- a/src/DynamicResponsive.tsx
+++ b/src/DynamicResponsive.tsx
@@ -1,11 +1,16 @@
+import React, {
+  FC,
+  useCallback,
+  useEffect,
+  useState,
+  useTransition,
+} from "react"
+
 /**
  * TODO: This is the deprecated runtime media-query component from Reaction.
  *       It can probably be simplified somewhat if we’re not going to be using
  *       it directly any longer.
  */
-
-import React from "react"
-
 /** TODO */
 export type MediaQueries<M extends string = string> = { [K in M]: string }
 
@@ -30,14 +35,46 @@ export interface ResponsiveProviderState {
   mediaQueryMatches: MediaQueryMatches
 }
 
-const shallowEqual = (a: MediaQueryMatches, b: MediaQueryMatches) => {
+export const shallowEqual = (a: MediaQueryMatches, b: MediaQueryMatches) => {
   for (const key in a) {
     if (a[key] !== b[key]) return false
   }
   return true
 }
+/**
+ * Create an array of media matchers that can validate each media query
+ */
+const setupMatchers = (mediaQueries: MediaQueries): MediaQueryMatchers => {
+  return Object.keys(mediaQueries).reduce(
+    (matchers, key) => ({
+      ...matchers,
+      [key]: window.matchMedia(mediaQueries[key]),
+    }),
+    {}
+  )
+}
 
-/** TODO */
+/**
+ * Uses the matchers to build a map of the states of each media query
+ */
+const checkMatchers = (
+  mediaQueryMatchers: MediaQueryMatchers
+): MediaQueryMatches => {
+  return Object.keys(mediaQueryMatchers).reduce(
+    (matches, key) => ({
+      ...matches,
+      [key]: mediaQueryMatchers[key].matches,
+    }),
+    {}
+  )
+}
+
+const isSupportedEnvironment = () => {
+  return (
+    typeof window !== "undefined" && typeof window.matchMedia !== "undefined"
+  )
+}
+
 export function createResponsiveComponents<M extends string>() {
   const ResponsiveContext = React.createContext({})
   ResponsiveContext.displayName = "Media.DynamicContext"
@@ -45,132 +82,110 @@ export function createResponsiveComponents<M extends string>() {
   const ResponsiveConsumer: React.FunctionComponent<
     React.ConsumerProps<MediaQueryMatches<M>>
   > = ResponsiveContext.Consumer as React.FunctionComponent<
-    React.ConsumerProps<any>
+    React.ConsumerProps<any> & { children: any }
   >
 
-  return {
-    Consumer: ResponsiveConsumer,
-    Provider: class ResponsiveProvider extends React.Component<
-      ResponsiveProviderProps<M>,
-      ResponsiveProviderState
-    > {
-      constructor(props: ResponsiveProviderProps<M>) {
-        super(props)
-        let mediaQueryMatchers: MediaQueryMatchers | undefined = undefined
-        let mediaQueryMatches: MediaQueryMatches
+  const ResponsiveProvider: FC<ResponsiveProviderProps<M>> = ({
+    mediaQueries,
+    initialMatchingMediaQueries,
+    children,
+  }) => {
+    /**
+     * TODO: The class component lifecycle shouldComponentUpdate
+     * has to be migrated to a functional component.
+     */
 
-        if (this.isSupportedEnvironment()) {
-          mediaQueryMatchers = this.setupMatchers(props.mediaQueries)
-          mediaQueryMatches = this.checkMatchers(mediaQueryMatchers)
-        } else {
-          mediaQueryMatches = Object.keys(props.mediaQueries).reduce(
-            (matches, key) => ({
-              ...matches,
-              [key]:
-                !!props.initialMatchingMediaQueries &&
-                props.initialMatchingMediaQueries.includes(key as M),
-            }),
-            {}
-          )
-        }
+    // const shouldComponentUpdate = (
+    //   nextProps: Readonly<ResponsiveProviderProps<M>>,
+    //   nextState: Readonly<ResponsiveProviderState>
+    // ) => {
+    //   if (!this.state.mediaQueryMatchers) return false
+    //   if (nextProps.children !== this.props.children) return true
+    //   if (
+    //     shallowEqual(
+    //       this.state.mediaQueryMatches,
+    //       nextState.mediaQueryMatches
+    //     )
+    //   ) {
+    //     return false
+    //   }
+    //   return true
+    // }
 
-        this.state = {
-          mediaQueryMatchers,
-          mediaQueryMatches,
-        }
+    const [isPending, startTransition] = useTransition()
+
+    const [mediaQueryMatchers] = useState(() => {
+      let mediaQueryMatchers: MediaQueryMatchers | undefined = undefined
+
+      if (isSupportedEnvironment() && mediaQueries != null) {
+        mediaQueryMatchers = setupMatchers(mediaQueries)
       }
+      return mediaQueryMatchers
+    })
 
-      isSupportedEnvironment = () => {
-        return (
-          typeof window !== "undefined" &&
-          typeof window.matchMedia !== "undefined"
-        )
-      }
-
-      /**
-       * Create an array of media matchers that can validate each media query
-       */
-      setupMatchers = (mediaQueries: MediaQueries): MediaQueryMatchers => {
-        return Object.keys(mediaQueries).reduce(
-          (matchers, key) => ({
-            ...matchers,
-            [key]: window.matchMedia(mediaQueries[key]),
-          }),
-          {}
-        )
-      }
-
-      /**
-       * Uses the matchers to build a map of the states of each media query
-       */
-      checkMatchers = (
-        mediaQueryMatchers: MediaQueryMatchers
-      ): MediaQueryMatches => {
-        return Object.keys(mediaQueryMatchers).reduce(
+    const [mediaQueryMatches, setMediaQueryMatches] = useState(() => {
+      let mediaQueryMatches: MediaQueryMatches
+      if (isSupportedEnvironment() && mediaQueryMatchers != null) {
+        mediaQueryMatches = checkMatchers(mediaQueryMatchers)
+      } else {
+        mediaQueryMatches = Object.keys(mediaQueries).reduce(
           (matches, key) => ({
             ...matches,
-            [key]: mediaQueryMatchers[key].matches,
+            [key]:
+              !!initialMatchingMediaQueries &&
+              initialMatchingMediaQueries.includes(key as M),
           }),
           {}
         )
       }
+      return mediaQueryMatches
+    })
 
-      /**
-       * The function that will be called any time a media query status changes
-       */
-      mediaQueryStatusChangedCallback = () => {
-        const mediaQueryMatches = this.checkMatchers(
-          this.state.mediaQueryMatchers!
-        )
-        this.setState({
-          mediaQueryMatches,
+    /**
+     * The function that will be called any time a media query status changes
+     */
+    const mediaQueryStatusChangedCallback = useCallback(() => {
+      if (isSupportedEnvironment() && mediaQueryMatchers) {
+        const mediaQueryMatches = checkMatchers(mediaQueryMatchers)
+        startTransition(() => {
+          setMediaQueryMatches(mediaQueryMatches)
+        })
+      }
+    }, [mediaQueryMatchers])
+
+    useEffect(() => {
+      if (mediaQueryMatchers) {
+        Object.values(mediaQueryMatchers).forEach((matcher) => {
+          matcher.addEventListener("change", mediaQueryStatusChangedCallback)
         })
       }
 
-      // Lifecycle methods
-
-      componentDidMount() {
-        if (this.state.mediaQueryMatchers) {
-          const { mediaQueryStatusChangedCallback } = this
-          Object.values(this.state.mediaQueryMatchers).forEach(matcher => {
-            matcher.addListener(mediaQueryStatusChangedCallback)
-          })
-        }
-      }
-
-      componentWillUnmount() {
-        if (this.state.mediaQueryMatchers) {
-          const { mediaQueryStatusChangedCallback } = this
-          Object.values(this.state.mediaQueryMatchers).forEach(matcher =>
-            matcher.removeListener(mediaQueryStatusChangedCallback)
+      return () => {
+        if (mediaQueryMatchers) {
+          Object.values(mediaQueryMatchers).forEach((matcher) =>
+            matcher.removeEventListener(
+              "change",
+              mediaQueryStatusChangedCallback
+            )
           )
         }
       }
+    }, [mediaQueryStatusChangedCallback])
 
-      shouldComponentUpdate(
-        nextProps: Readonly<ResponsiveProviderProps<M>>,
-        nextState: Readonly<ResponsiveProviderState>
-      ) {
-        if (!this.state.mediaQueryMatchers) return false
-        if (nextProps.children !== this.props.children) return true
-        if (
-          shallowEqual(
-            this.state.mediaQueryMatches,
-            nextState.mediaQueryMatches
-          )
-        ) {
-          return false
-        }
-        return true
-      }
+    return (
+      <ResponsiveContext.Provider
+        value={{
+          mediaQueryMatches,
+          isPending,
+        }}
+      >
+        {children}
+      </ResponsiveContext.Provider>
+    )
+  }
 
-      render() {
-        return (
-          <ResponsiveContext.Provider value={this.state.mediaQueryMatches}>
-            {this.props.children}
-          </ResponsiveContext.Provider>
-        )
-      }
-    },
+  return {
+    Consumer: ResponsiveConsumer,
+    Provider: ResponsiveProvider,
   }
 }

--- a/src/Media.tsx
+++ b/src/Media.tsx
@@ -349,7 +349,7 @@ export function createMedia<
   }>({ hasParentMedia: false, breakpointProps: {} })
   MediaContext.displayName = "MediaParent.Context"
 
-  const getMediaContextValue = memoize((onlyMatch) => ({
+  const getMediaContextValue = memoize(onlyMatch => ({
     onlyMatch,
   }))
 
@@ -378,7 +378,7 @@ export function createMedia<
           <DynamicResponsive.Consumer>
             {({ mediaQueryMatches: matches, isPending }) => {
               const matchingMediaQueries = Object.keys(matches).filter(
-                (key) => matches[key]
+                key => matches[key]
               )
 
               const MediaContextValue = getMediaContextValue(
@@ -387,7 +387,7 @@ export function createMedia<
 
               return (
                 <MediaContext.Provider
-                  value={{ ...MediaContextValue, isPending: isPending }}
+                  value={{ ...MediaContextValue, isPending }}
                 >
                   {children}
                 </MediaContext.Provider>
@@ -430,12 +430,13 @@ export function createMedia<
         interaction,
         ...breakpointProps
       } = props
-      const mediaParentContextValue =
-        this.getMediaParentContextValue(breakpointProps)
+      const mediaParentContextValue = this.getMediaParentContextValue(
+        breakpointProps
+      )
 
       return (
         <MediaParentContext.Consumer>
-          {(mediaParentContext) => {
+          {mediaParentContext => {
             return (
               <MediaParentContext.Provider value={mediaParentContextValue}>
                 <MediaContext.Consumer>
@@ -533,7 +534,7 @@ export function createMedia<
 const MutuallyExclusiveProps: string[] = MediaQueries.validKeys()
 
 function validateProps(props) {
-  const selectedProps = Object.keys(props).filter((prop) =>
+  const selectedProps = Object.keys(props).filter(prop =>
     MutuallyExclusiveProps.includes(prop)
   )
   if (selectedProps.length < 1) {

--- a/src/Media.tsx
+++ b/src/Media.tsx
@@ -1,5 +1,6 @@
 // tslint:disable:jsdoc-format
 import React, { CSSProperties } from "react"
+import { SuspenseWrapper } from "./suspense/SuspenseWrapper"
 
 import { BreakpointConstraint } from "./Breakpoints"
 import { createResponsiveComponents } from "./DynamicResponsive"
@@ -349,7 +350,7 @@ export function createMedia<
   }>({ hasParentMedia: false, breakpointProps: {} })
   MediaContext.displayName = "MediaParent.Context"
 
-  const getMediaContextValue = memoize(onlyMatch => ({
+  const getMediaContextValue = memoize((onlyMatch) => ({
     onlyMatch,
   }))
 
@@ -359,10 +360,10 @@ export function createMedia<
     }
   > = ({ disableDynamicMediaQueries, onlyMatch, children }) => {
     if (disableDynamicMediaQueries) {
-      const MediaContextValue = getMediaContextValue(onlyMatch)
+      const mediaContextValue = getMediaContextValue(onlyMatch)
 
       return (
-        <MediaContext.Provider value={MediaContextValue}>
+        <MediaContext.Provider value={mediaContextValue}>
           {children}
         </MediaContext.Provider>
       )
@@ -378,16 +379,16 @@ export function createMedia<
           <DynamicResponsive.Consumer>
             {({ mediaQueryMatches: matches, isPending }) => {
               const matchingMediaQueries = Object.keys(matches).filter(
-                key => matches[key]
+                (key) => matches[key]
               )
 
-              const MediaContextValue = getMediaContextValue(
+              const mediaContextValue = getMediaContextValue(
                 intersection(matchingMediaQueries, onlyMatch)
               )
 
               return (
                 <MediaContext.Provider
-                  value={{ ...MediaContextValue, isPending }}
+                  value={{ ...mediaContextValue, isPending }}
                 >
                   {children}
                 </MediaContext.Provider>
@@ -430,13 +431,12 @@ export function createMedia<
         interaction,
         ...breakpointProps
       } = props
-      const mediaParentContextValue = this.getMediaParentContextValue(
-        breakpointProps
-      )
+      const mediaParentContextValue =
+        this.getMediaParentContextValue(breakpointProps)
 
       return (
         <MediaParentContext.Consumer>
-          {mediaParentContext => {
+          {(mediaParentContext) => {
             return (
               <MediaParentContext.Provider value={mediaParentContextValue}>
                 <MediaContext.Consumer>
@@ -492,6 +492,7 @@ export function createMedia<
                           breakpointProps
                         )
                       ).length > 0
+
                     const renderChildren =
                       doesMatchParent &&
                       (onlyMatch === undefined ||
@@ -501,14 +502,35 @@ export function createMedia<
                         ))
 
                     if (props.children instanceof Function) {
-                      return props.children(
-                        className,
-                        renderChildren,
-                        isPending
+                      return (
+                        <>
+                          <SuspenseWrapper
+                            active={renderChildren}
+                            isPending={isPending}
+                          >
+                            {props.children(
+                              className,
+                              renderChildren,
+                              isPending
+                            )}
+                          </SuspenseWrapper>
+                        </>
+                      )
+                    } else {
+                      return (
+                        <SuspenseWrapper
+                          active={renderChildren}
+                          isPending={isPending}
+                        >
+                          <div
+                            className={`fresnel-container ${className} ${passedClassName}`}
+                            style={style}
+                          >
+                            {renderChildren ? props.children : null}
+                          </div>
+                        </SuspenseWrapper>
                       )
                     }
-                    console.log("Warning: Child has to be a function")
-                    return null
                   }}
                 </MediaContext.Consumer>
               </MediaParentContext.Provider>
@@ -534,7 +556,7 @@ export function createMedia<
 const MutuallyExclusiveProps: string[] = MediaQueries.validKeys()
 
 function validateProps(props) {
-  const selectedProps = Object.keys(props).filter(prop =>
+  const selectedProps = Object.keys(props).filter((prop) =>
     MutuallyExclusiveProps.includes(prop)
   )
   if (selectedProps.length < 1) {

--- a/src/Media.tsx
+++ b/src/Media.tsx
@@ -1,16 +1,16 @@
 // tslint:disable:jsdoc-format
-
 import React, { CSSProperties } from "react"
+
+import { BreakpointConstraint } from "./Breakpoints"
 import { createResponsiveComponents } from "./DynamicResponsive"
 import { MediaQueries } from "./MediaQueries"
 import {
-  intersection,
-  propKey,
-  createClassName,
   castBreakpointsToIntegers,
+  createClassName,
+  intersection,
   memoize,
+  propKey,
 } from "./Utils"
-import { BreakpointConstraint } from "./Breakpoints"
 
 /**
  * A render prop that can be used to render a different container element than
@@ -20,7 +20,8 @@ import { BreakpointConstraint } from "./Breakpoints"
  */
 export type RenderProp = (
   className: string,
-  renderChildren: boolean
+  renderChildren: boolean,
+  isPending?: boolean
 ) => React.ReactNode
 
 // TODO: All of these props should be mutually exclusive. Using a union should
@@ -216,6 +217,8 @@ export interface MediaContextProviderProps<M> {
    * will be triggered, which could lead to unintended side-effects.
    */
   disableDynamicMediaQueries?: boolean
+
+  isPending?: boolean
 }
 
 export interface CreateMediaConfig {
@@ -346,7 +349,7 @@ export function createMedia<
   }>({ hasParentMedia: false, breakpointProps: {} })
   MediaContext.displayName = "MediaParent.Context"
 
-  const getMediaContextValue = memoize(onlyMatch => ({
+  const getMediaContextValue = memoize((onlyMatch) => ({
     onlyMatch,
   }))
 
@@ -373,9 +376,9 @@ export function createMedia<
           )}
         >
           <DynamicResponsive.Consumer>
-            {matches => {
+            {({ mediaQueryMatches: matches, isPending }) => {
               const matchingMediaQueries = Object.keys(matches).filter(
-                key => matches[key]
+                (key) => matches[key]
               )
 
               const MediaContextValue = getMediaContextValue(
@@ -383,7 +386,9 @@ export function createMedia<
               )
 
               return (
-                <MediaContext.Provider value={MediaContextValue}>
+                <MediaContext.Provider
+                  value={{ ...MediaContextValue, isPending: isPending }}
+                >
                   {children}
                 </MediaContext.Provider>
               )
@@ -425,17 +430,16 @@ export function createMedia<
         interaction,
         ...breakpointProps
       } = props
-      const mediaParentContextValue = this.getMediaParentContextValue(
-        breakpointProps
-      )
+      const mediaParentContextValue =
+        this.getMediaParentContextValue(breakpointProps)
 
       return (
         <MediaParentContext.Consumer>
-          {mediaParentContext => {
+          {(mediaParentContext) => {
             return (
               <MediaParentContext.Provider value={mediaParentContextValue}>
                 <MediaContext.Consumer>
-                  {({ onlyMatch } = {}) => {
+                  {({ onlyMatch, isPending } = {}) => {
                     let className: string | null
                     if (props.interaction) {
                       className = createClassName(
@@ -496,18 +500,14 @@ export function createMedia<
                         ))
 
                     if (props.children instanceof Function) {
-                      return props.children(className, renderChildren)
-                    } else {
-                      return (
-                        <div
-                          className={`fresnel-container ${className} ${passedClassName}`}
-                          style={style}
-                          suppressHydrationWarning={!renderChildren}
-                        >
-                          {renderChildren ? props.children : null}
-                        </div>
+                      return props.children(
+                        className,
+                        renderChildren,
+                        isPending
                       )
                     }
+                    console.log("Warning: Child has to be a function")
+                    return null
                   }}
                 </MediaContext.Consumer>
               </MediaParentContext.Provider>
@@ -533,7 +533,7 @@ export function createMedia<
 const MutuallyExclusiveProps: string[] = MediaQueries.validKeys()
 
 function validateProps(props) {
-  const selectedProps = Object.keys(props).filter(prop =>
+  const selectedProps = Object.keys(props).filter((prop) =>
     MutuallyExclusiveProps.includes(prop)
   )
   if (selectedProps.length < 1) {

--- a/src/__test__/Media.test.tsx
+++ b/src/__test__/Media.test.tsx
@@ -464,73 +464,6 @@ describe("Media", () => {
     })
   })
 
-  describe("during hydration", () => {
-    // FIXME: Unable to reproduce this here, so we'll do a more synthetic test.
-    xit("does not warn about Media components that do not match and are empty", done => {
-      const spy = jest.spyOn(console, "error")
-
-      const App = () => (
-        <MediaContextProvider>
-          <Media at="extra-small">
-            <div className="extra-small" />
-          </Media>
-          <Media at="medium">
-            <div className="medium" />
-          </Media>
-          <Media greaterThanOrEqual="large">
-            <div className="large" />
-          </Media>
-        </MediaContextProvider>
-      )
-
-      const container = document.createElement("div")
-      document.body.appendChild(container)
-
-      mockCurrentDynamicBreakpoint("medium")
-
-      container.innerHTML = ReactDOMServer.renderToString(<App />)
-      ReactDOM.hydrate(<App />, container, () => {
-        expect(spy).not.toHaveBeenCalled()
-        done()
-      })
-    })
-
-    // This is the best we can do until we figure out a way to reproduce a
-    // warning, as per above.
-    it("does not warn about Media components that do not match and are empty", () => {
-      mockCurrentDynamicBreakpoint("medium")
-
-      const query = (renderer
-        .create(
-          <MediaContextProvider>
-            <Media at="extra-small">
-              <span className="extra-small" />
-            </Media>
-            <Media at="medium">
-              <span className="medium" />
-            </Media>
-            <Media at="large">
-              <span className="large" />
-            </Media>
-          </MediaContextProvider>
-        )
-        .toJSON() as any) as ReactTestRendererJSON[]
-
-      expect(
-        query.find(e => e.props.className.includes("extra-small")).props
-          .suppressHydrationWarning
-      ).toEqual(true)
-      expect(
-        query.find(e => e.props.className.includes("medium")).props
-          .suppressHydrationWarning
-      ).toEqual(false)
-      expect(
-        query.find(e => e.props.className.includes("large")).props
-          .suppressHydrationWarning
-      ).toEqual(true)
-    })
-  })
-
   describe("prevent nested unnecessary renders", () => {
     it("only renders one element when Media is nested within Media", () => {
       const query = renderer.create(
@@ -761,8 +694,8 @@ function mockCurrentDynamicBreakpoint(at) {
     // Return mock object that only matches the mocked breakpoint
     return {
       matches: key === at,
-      addListener: jest.fn(),
-      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
     }
   })
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
 export { createMedia } from "./Media"
 export { BreakpointConstraint as BreakpointKey } from "./Breakpoints"
-export * from "./suspense"
+export { Suspender } from "./suspense/Suspender"
+export { SuspenseWrapper } from "./suspense/SuspenseWrapper"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,2 +1,3 @@
 export { createMedia } from "./Media"
 export { BreakpointConstraint as BreakpointKey } from "./Breakpoints"
+export * from "./suspense"

--- a/src/suspense/Suspender.tsx
+++ b/src/suspense/Suspender.tsx
@@ -1,0 +1,83 @@
+import { FC, ReactNode, useEffect } from "react"
+
+import { createWakeable, Wakeable } from "./suspense"
+
+export const cache = new Map<string, Wakeable<unknown>>()
+
+export interface SuspenderProps {
+  id: string
+  freeze: boolean
+  children: ReactNode
+}
+
+/**
+ * The task of the suspender component is to instruct the suspense boundary,
+ * depending on the value of the "active" property.
+ *
+ * An important aspect is that the instruction is not to be executed
+ * as a side effect but in the render step.
+ *
+ * 1. Active - true - return the child elements
+ * 2. Active - false - creation and submission of a promise (Promise / Thenable)
+ *
+ * After the first render
+ * 3. Active - false -> true - Promise fulfilment + return of the child elements
+ * 4. Active - true -> false - Creation and submission of a promise
+ *
+ * 5. Active - false -> true -> false - Reuse and discard a promise
+ *
+ * Stable active
+ * 6. Active - true -> true - Return of the child elements
+ * 7. Active - false -> false - Reuse and submission of a promise (*1)
+ *
+ * Important: If a suspense boundary is suspended in the current
+ * render step and this should also apply to subsequent render steps,
+ * a commitment must be made repeatedly.
+ */
+
+export const Suspender: FC<SuspenderProps & { children: any }> = ({
+  id,
+  freeze,
+  children,
+}) => {
+  useEffect(() => {
+    return () => {
+      cache.delete(id)
+    }
+  }, [])
+
+  /**
+   * If !freeze (the breakpoint matches) return children
+   */
+
+  if (!freeze) {
+    if (!cache.has(id)) {
+      // render children; skip the promise phase (case 1 & 6)
+      return children
+    } else if (cache.has(id)) {
+      const weakable = cache.get(id)
+      // resolve promise previously thrown, render children (case 3)
+      weakable?.resolve()
+      cache.delete(id)
+      return children
+    }
+  }
+
+  /**
+   * If freeze (the breakpoint does not match) throw promise to suspend children / return nothing not even null
+   */
+  if (freeze) {
+    if (!cache.has(id)) {
+      // (case 2 & 4)
+      const weakable = createWakeable()
+      cache.set(id, weakable)
+      throw weakable
+    } else if (cache.has(id)) {
+      // (case 5 & 7)
+      const weakable = cache.get(id)
+      throw weakable
+    }
+  }
+
+  // do not return children
+}

--- a/src/suspense/SuspenseWrapper.tsx
+++ b/src/suspense/SuspenseWrapper.tsx
@@ -1,0 +1,75 @@
+import React, {
+  FC,
+  ReactNode,
+  Suspense,
+  useEffect,
+  useId,
+  useState,
+  useTransition,
+} from "react"
+
+import { Suspender } from "./Suspender"
+
+const isBrowser = () => typeof window !== "undefined"
+
+export interface SuspenseWrapperProps {
+  active: boolean
+  isPending: boolean | undefined
+  children: ReactNode
+}
+
+/**
+ * Background:
+ * The feature available in React 17 for canceling out unused DOM elements got eliminated in React 18.
+ * The only option for replicating the behavior is to use Suspense and selectively suspend currently
+ * unused components through Suspense wrappers / Suspenders.
+ *
+ * In the context of the approach pursued by fresnel, a variant of a component set that matches
+ * a current breakpoint renders; any unmatched component gets suspended.
+ *
+ * The task of the suspense wrapper component is to interrupt the suspense component
+ * by necessary transition pauses.
+ *
+ * Important:
+ * React 18 requires the use of a transition when a value enters a suspense boundary.
+ * A Suspense boundary does not serve an API to suspend embedded components.
+ *
+ * The only way is to make a commitment to the Suspense boundary, this must be done within
+ * a Suspense boundary, see component Suspender and its "active" property.
+ *
+ * The only way is to trigger a commitment to the suspense boundary within a suspense boundary,
+ * reference component Suspender, and its "active" property.
+ */
+export const SuspenseWrapper: FC<SuspenseWrapperProps> = ({
+  active,
+  isPending: activeIsPending,
+  children,
+}) => {
+  const id = useId()
+
+  const [, setRerenderSuspended] = useState(false)
+  const [
+    rerenderSuspendedIsPending,
+    startRerenderSuspendedTransition,
+  ] = useTransition()
+
+  useEffect(() => {
+    if (!active) {
+      startRerenderSuspendedTransition(() => {
+        setRerenderSuspended(value => !value)
+      })
+    }
+  }, [active])
+
+  if (activeIsPending && rerenderSuspendedIsPending) {
+    return null
+  }
+
+  return (
+    <Suspense fallback={null}>
+      <Suspender id={id} freeze={!isBrowser() ? false : !active}>
+        {children}
+      </Suspender>
+    </Suspense>
+  )
+}

--- a/src/suspense/suspense.tsx
+++ b/src/suspense/suspense.tsx
@@ -1,0 +1,85 @@
+export const STATUS_PENDING = 0
+export const STATUS_RESOLVED = 1
+export const STATUS_REJECTED = 2
+
+export type PendingRecord<T> = {
+  status: 0
+  value: Wakeable<T>
+}
+
+export type ResolvedRecord<T> = {
+  status: 1
+  value: T
+}
+
+export type RejectedRecord = {
+  status: 2
+  value: any
+}
+
+export type Record<T> = PendingRecord<T> | ResolvedRecord<T> | RejectedRecord
+
+// This type defines the subset of the Promise API that React uses (the .then method to add success/error callbacks).
+// You can use a Promise for this, but Promises have a downside (the microtask queue).
+// You can also create your own "thennable" if you want to support synchronous resolution/rejection.
+export interface Thennable<T> {
+  then(onFulfill: (value: T) => any, onReject: () => any): void | Thennable<T>
+}
+
+// Convenience type used by Suspense caches.
+// Adds the ability to resolve or reject a pending Thennable.
+export interface Wakeable<T> extends Thennable<T> {
+  reject(error: any): void
+  resolve(value?: T): void
+}
+// A "thennable" is a subset of the Promise API.
+// We could use a Promise as thennable, but Promises have a downside: they use the microtask queue.
+// An advantage to creating a custom thennable is synchronous resolution (or rejection).
+//
+// A "wakeable" is a "thennable" that has convenience resolve/reject methods.
+export function createWakeable<T>(): Wakeable<T> {
+  const resolveCallbacks: Set<(value: T) => void> = new Set()
+  const rejectCallbacks: Set<(error: Error) => void> = new Set()
+
+  const wakeable: Wakeable<T> = {
+    then(
+      resolveCallback: (value: T) => void,
+      rejectCallback: (error: Error) => void
+    ) {
+      resolveCallbacks.add(resolveCallback)
+      rejectCallbacks.add(rejectCallback)
+    },
+    reject(error: Error) {
+      let thrown = false
+      let thrownValue
+      rejectCallbacks.forEach((rejectCallback) => {
+        try {
+          rejectCallback(error)
+        } catch (error) {
+          thrown = true
+          thrownValue = error
+        }
+      })
+      if (thrown) {
+        throw thrownValue
+      }
+    },
+    resolve(value: T) {
+      let thrown = false
+      let thrownValue
+      resolveCallbacks.forEach((resolveCallback) => {
+        try {
+          resolveCallback(value)
+        } catch (error) {
+          thrown = true
+          thrownValue = error
+        }
+      })
+      if (thrown) {
+        throw thrownValue
+      }
+    },
+  }
+
+  return wakeable
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6601,10 +6601,10 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@1.17.1:
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.1.tgz#ed64b4e93e370cb8a25b9ef7fef3e4fd1c0995db"
-  integrity sha512-TzGRNvuUSmPgwivDqkZ9tM/qTGW9hqDKWOE9YHiyQdixlKbv7kvEqsmDPrcHJTKwthU774TQwZXVtaQ/mMsvjg==
+prettier@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 pretty-format@^23.5.0:
   version "23.5.0"


### PR DESCRIPTION
Closes https://github.com/artsy/fresnel/pull/289
Closes https://github.com/artsy/fresnel/issues/260

All credit goes to @gurkerl83 and the work he spearheaded in #289 and the investigations in https://github.com/artsy/fresnel/issues/260. Much appreciated! 

This PR integrates that work and updates the examples a bit. One thing that I did do here after experimenting within the NextJS example was integrate the suspense boundary directly into `<Media>` so that we don't have any forced breaking changes in the API and the library behaves as it did before. 

In my testing (and updated in this PR's examples), `<Suspense>` still works as one would expect within the children of `<Media>`, even though `<SuspenseBoundary>` is contained higher-up. I know Dan mentioned that this is a UI thing and that `<Suspense>` should only ever be invoked by library consumers in userland, but in this case it makes sense to keep it in the lib and things (seem) to work just fine. We should track changes to React and update accordingly. 

@gurkerl83 - do you have any strong objections to this? 

#### To test: 
```sh
yarn link
yarn watch 
```
and then in another tab
```sh
cd examples/nextjs
yarn link @artsy/fresnel 
yarn dev
```

Will update tests tomorrow and cut a new release. 