### PR TITLE
docs(react-18): Update to remove unnecessary warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,37 +7,18 @@
 
 – https://en.wikipedia.org/wiki/Fresnel_equations
 
-### ⚠️ React 18 Notice
-
-Due to React 18 more strictly handling server-side rendering rehydration full
-SSR support is incompatable with any version greater than 17. See
-[this issue](https://github.com/artsy/fresnel/issues/260) to track our progress in fixing this issue, and Dan
-Abromov's
-[comment here](https://github.com/facebook/react/issues/23381#issuecomment-1096899474).
-
-In the meantime -- for users of server-side rendering features -- you can
-disable DOM cleaning optimizations by setting `disableDynamicMediaQueries` on
-the context like so and things should work:
-
-```tsx
-<MediaContextProvider disableDynamicMediaQueries>
-  <Media at='xs'>
-    <MobileApp />
-  </Media>
-  <Media greaterThan='xs'>
-    <DesktopApp />
-  </Media>
-<MediaContextProvider>
-```
-
-Note that this will fire all effects within sub components for each breakpoint
-on re-hydration. For some users this could be an issue; for many others, no
-problem at all.
-
 ## Installation
+
+For users of **React v18** or later:
 
 ```sh
   yarn add @artsy/fresnel
+```
+
+For those on **React v17** or below:
+
+```sh
+  yarn add @artsy/fresnel@3.5.0
 ```
 
 **Table of Contents**

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/artsy/fresnel#readme",
   "peerDependencies": {
-    "react": ">=16.3.0"
+    "react": ">=18.0.0"
   },
   "devDependencies": {
     "@artsy/auto-config": "1.2.0",


### PR DESCRIPTION
Removes no longer necessary warning about react 18 incompatibility as that has been fixed here: https://github.com/artsy/fresnel/pull/290 