### PR TITLE
React 18 Support: Cleanup DOM during hydration to avoid mismatch

### DIFF
--- a/examples/kitchen-sink/src/App.tsx
+++ b/examples/kitchen-sink/src/App.tsx
@@ -94,44 +94,42 @@ export const App: React.FunctionComponent = () => (
          * rendered.
          */}
         <Media lessThan="sm">
-          {className => (
+          {(className, renderChildren) => (
             <li className={className} style={ExtraSmallStyle}>
-              xs
+              {renderChildren ? `xs` : null}
             </li>
           )}
         </Media>
         <Media between={["sm", "lg"]}>
-          {(className, renderChildren) =>
-            renderChildren && (
-              <>
-                <li
-                  className={className}
-                  style={{
-                    ...SmallStyle,
-                    height: "100px",
-                    lineHeight: "100px",
-                  }}
-                >
-                  sm
-                </li>
-                <li
-                  className={className}
-                  style={{
-                    ...MediumStyle,
-                    height: "100px",
-                    lineHeight: "100px",
-                  }}
-                >
-                  md
-                </li>
-              </>
-            )
-          }
+          {(className, renderChildren) => (
+            <>
+              <li
+                className={className}
+                style={{
+                  ...SmallStyle,
+                  height: "100px",
+                  lineHeight: "100px",
+                }}
+              >
+                {renderChildren ? `sm` : null}
+              </li>
+              <li
+                className={className}
+                style={{
+                  ...MediumStyle,
+                  height: "100px",
+                  lineHeight: "100px",
+                }}
+              >
+                {renderChildren ? `md` : null}
+              </li>
+            </>
+          )}
         </Media>
         <Media greaterThanOrEqual="lg">
-          {className => (
+          {(className, renderChildren) => (
             <li className={className} style={LargeStyle}>
-              lg
+              {renderChildren ? `lg` : null}
             </li>
           )}
         </Media>

--- a/examples/kitchen-sink/src/client.tsx
+++ b/examples/kitchen-sink/src/client.tsx
@@ -1,11 +1,12 @@
 import React from "react"
-import ReactDOM from "react-dom"
+import ReactDOM from "react-dom/client"
 import { App } from "./app"
 import { SSRStyleID, mediaStyle } from "./Media"
 
+let root
+
 if (document.getElementById(SSRStyleID)) {
-  // rehydration
-  ReactDOM.hydrate(<App />, document.getElementById("react-root"))
+  root = ReactDOM.hydrateRoot(document.getElementById("react-root"), <App />)
 } else {
   // client-side only
   const style = document.createElement("style")
@@ -13,5 +14,7 @@ if (document.getElementById(SSRStyleID)) {
   style.id = SSRStyleID
   style.innerText = mediaStyle
   document.getElementsByTagName("head")[0].appendChild(style)
-  ReactDOM.render(<App />, document.getElementById("react-root"))
+
+  root = ReactDOM.createRoot(document.getElementById("react-root"))
+  root.render(<App />)
 }

--- a/examples/kitchen-sink/src/server.tsx
+++ b/examples/kitchen-sink/src/server.tsx
@@ -81,7 +81,6 @@ app.get("/rehydration", (req, res) => {
         <div id="react-root">
           ${ReactDOMServer.renderToString(
             <MediaContextProvider
-              disableDynamicMediaQueries
               onlyMatch={onlyMatchListForUserAgent(req.header(
                 "User-Agent"
               ) as string)}

--- a/examples/nextjs/src/pages/index.tsx
+++ b/examples/nextjs/src/pages/index.tsx
@@ -2,7 +2,7 @@ import { Media, MediaContextProvider } from "../media"
 
 export default function HomePage() {
   return (
-    <MediaContextProvider disableDynamicMediaQueries>
+    <MediaContextProvider>
       <Media at="xs">Hello mobile!</Media>
       <Media greaterThan="xs">Hello desktop!</Media>
     </MediaContextProvider>

--- a/examples/ssr-rendering/src/App.tsx
+++ b/examples/ssr-rendering/src/App.tsx
@@ -4,7 +4,7 @@ import { Media, MediaContextProvider } from "./Media"
 
 export const App = () => {
   return (
-    <MediaContextProvider disableDynamicMediaQueries>
+    <MediaContextProvider>
       <Media interaction="landscape">landscape</Media>
       <Media interaction="portrait">portrait</Media>
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/artsy/fresnel#readme",
   "peerDependencies": {
-    "react": ">=16.3.0"
+    "react": ">=18.0.0"
   },
   "devDependencies": {
     "@artsy/auto-config": "1.2.0",

--- a/src/Media.tsx
+++ b/src/Media.tsx
@@ -476,9 +476,9 @@ export function createMedia<
      * If we're on the client, this is the first render, and we are not going
      * to render the children, we need to cleanup the the server-rendered HTML
      * to avoid a hydration mismatch on React 18+. We do this by grabbing the
-     * already-existing element directly from the DOM using the unique class id
-     * and clearing its contents. This solution follows one of the suggestions
-     * from Dan Abromov here:
+     * already-existing element(s) directly from the DOM using the unique class
+     * id and clearing its contents. This solution follows one of the
+     * suggestions from Dan Abromov here:
      *
      * https://github.com/facebook/react/issues/23381#issuecomment-1096899474
      *
@@ -488,8 +488,8 @@ export function createMedia<
      * on initial hydration.
      */
     if (isClient && isFirstRender && !renderChildren) {
-      const containerEl = document.getElementsByClassName(uniqueComponentId)[0]
-      if (!!containerEl) containerEl.innerHTML = ""
+      const containerEls = document.getElementsByClassName(uniqueComponentId)
+      Array.from(containerEls).forEach(el => (el.innerHTML = ""))
     }
 
     return (

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,5 +1,6 @@
 import { MediaBreakpointProps } from "./Media"
 import { BreakpointConstraintKey } from "./Breakpoints"
+import { useRef } from "react"
 
 /**
  * Extracts the single breakpoint prop from the props object.
@@ -72,5 +73,19 @@ export function memoize<F extends (...args: any[]) => void>(func: F) {
       results[argsKey] = func(...args)
     }
     return results[argsKey]
+  }
+}
+
+/**
+ * Hook to determine if the current render is the first render.
+ */
+export function useIsFirstRender(): boolean {
+  const isFirst = useRef(true)
+
+  if (isFirst.current) {
+    isFirst.current = false
+    return true
+  } else {
+    return false
   }
 }


### PR DESCRIPTION
Fixes #260 (hopefully 😅)

Hey folks! I've been following this issue for a while and am hoping to continue using `@artsy/fresnel` on React 18 and beyond. Even with current React 18 support via `disableDynamicMediaQueries`, `@artsy/fresnel` is still the best way I've found to dynamically SSR different markup for different devices.

I recently stumbled on [this gist](https://gist.github.com/OliverJAsh/e9a588e7e907101affe1a7696a25b1fd#file-skiprenderonclient-tsx) which demonstrates a method for avoiding hydration mismatches by using a combination of `useId` and some initial-render logic to clean up the DOM **during hydration**. While the example in the gist isn't realistic because it causes a Flash of Server Rendered Content™, I was intrigued by the idea and set out to see if I could integrate it into `@artsy/fresnel`.

While most of the previous efforts to resolve #260 have been related to using `<Suspense>` boundaries in clever ways, this method of DOM cleanup **is a supported solution** based on @gaearon's [comment on the React issue](https://github.com/facebook/react/issues/23381#issuecomment-1096899474):

> The supported solutions are:
> - Render all variants and let all effects fire.
> - Or patch up the HTML tree to prune the invisible branches before starting hydration.

TL;DR: I was successful at using this method within `@artsy/fresnel` to cleanup the DOM during hydration! I hope this resolves the issue going forward.
 
Some notes:
- This solution only supports React 18+ because it requires `useId`. Folks that need React 17 support can continue using an older version of `@artsy/fresnel`
- I refactored `Media` to a functional component instead of a class component, which drastically simplified it by allowing use of `useContext` instead of multiple nested `MediaParentContext.Provider` elements. However, by refactoring it in this way, it is no longer possible to determine the parent component's name for the "at is being used with the largest breakpoint." warning. I think this is a reasonable price to pay for simplicity and a working implementation for React 18!
- I have tested this approach on the `kitchen-sink` example and it works! I had to make a few tweaks to the example to properly call `renderChildren` on the inner content of rendered nodes with `className`. I believe that example was not using `renderChildren` properly. It may be important to expand on this usage in the `README`, but it should be possible with this approach to pass a custom render function that responds with multiple children nested in a fragment, as long as they all receive `className` and use `renderChildren` dynamically on _their_ children.
- I have published a version of this to `npm` at `@mgreenw/fresnel:7.0.0-alpha.2` for folks to try out / use for testing! Artsy team (@damassi): if you are able to publish your own alpha version based on this PR, that would be super helpful so others only need to change the package version and not the name for testing.
- The unit tests are all passing, which is great, but I saw that there were some TODOs around unit testing around hydration. Please let me know if there's anything I can do there to add testing -- it seems like it's tricky or not possible with the current setup?

Please let me know if you have feedback, and I would really appreciate folks testing this out on their own projects to see if you run into any issues at scale.