### PR TITLE
fix: Avoid undefined class name

### DIFF
--- a/src/Media.tsx
+++ b/src/Media.tsx
@@ -500,7 +500,7 @@ export function createMedia<
           } else {
             return (
               <div
-                className={`fresnel-container ${className} ${passedClassName}`}
+                className={["fresnel-container", className, passedClassName].filter(Boolean).join(" ")}
                 style={style}
                 suppressHydrationWarning={!renderChildren}
               >


### PR DESCRIPTION
<img width="627" alt="Screenshot 2023-11-02 at 10 20 40 AM" src="https://github.com/artsy/fresnel/assets/3906130/853fdbe9-0a2d-4c23-8a86-34d3c8c2b55f">

Very minior but currently `passedClassName` is optional and will print `undefined`, we can either add a default empty string or massage the class name a bit. 

