### PR TITLE
fix(types): Fix more type errors

### DIFF
--- a/dist/Media.d.ts
+++ b/dist/Media.d.ts
@@ -1,14 +1,14 @@
-import React, { CSSProperties } from "react";
-import { BreakpointConstraint } from "./Breakpoints";
+import React, { CSSProperties } from "react"
+import { BreakpointConstraint } from "./Breakpoints"
 /**
  * A render prop that can be used to render a different container element than
  * the default `div`.
  *
  * @see {@link MediaProps.children}.
  */
-export type RenderProp = (className: string, renderChildren: boolean) => React.ReactNode;
+export type RenderProp = (className: string, renderChildren: boolean) => any
 export interface MediaBreakpointProps<BreakpointKey = string> {
-    /**
+  /**
      * Children will only be shown if the viewport matches the specified
      * breakpoint. That is, a viewport width that’s higher than the configured
      * breakpoint value, but lower than the value of the next breakpoint, if any
@@ -31,8 +31,8 @@ export interface MediaBreakpointProps<BreakpointKey = string> {
        ```
      *
      */
-    at?: BreakpointKey;
-    /**
+  at?: BreakpointKey
+  /**
      * Children will only be shown if the viewport is smaller than the specified
      * breakpoint.
      *
@@ -50,8 +50,8 @@ export interface MediaBreakpointProps<BreakpointKey = string> {
        ```
      *
      */
-    lessThan?: BreakpointKey;
-    /**
+  lessThan?: BreakpointKey
+  /**
      * Children will only be shown if the viewport is greater than the specified
      * breakpoint.
      *
@@ -69,8 +69,8 @@ export interface MediaBreakpointProps<BreakpointKey = string> {
        ```
      *
      */
-    greaterThan?: BreakpointKey;
-    /**
+  greaterThan?: BreakpointKey
+  /**
      * Children will only be shown if the viewport is greater or equal to the
      * specified breakpoint.
      *
@@ -91,8 +91,8 @@ export interface MediaBreakpointProps<BreakpointKey = string> {
        ```
      *
      */
-    greaterThanOrEqual?: BreakpointKey;
-    /**
+  greaterThanOrEqual?: BreakpointKey
+  /**
      * Children will only be shown if the viewport is between the specified
      * breakpoints. That is, a viewport width that’s higher than or equal to the
      * small breakpoint value, but lower than the value of the large breakpoint.
@@ -111,10 +111,11 @@ export interface MediaBreakpointProps<BreakpointKey = string> {
        ```
      *
      */
-    between?: [BreakpointKey, BreakpointKey];
+  between?: [BreakpointKey, BreakpointKey]
 }
-export interface MediaProps<BreakpointKey, Interaction> extends MediaBreakpointProps<BreakpointKey> {
-    /**
+export interface MediaProps<BreakpointKey, Interaction>
+  extends MediaBreakpointProps<BreakpointKey> {
+  /**
      * Children will only be shown if the interaction query matches.
      *
      * @example
@@ -127,8 +128,8 @@ export interface MediaProps<BreakpointKey, Interaction> extends MediaBreakpointP
        <Media interaction="hover">ohai</Media>
        ```
      */
-    interaction?: Interaction;
-    /**
+  interaction?: Interaction
+  /**
      * The component(s) that should conditionally be shown, depending on the media
      * query matching.
      *
@@ -158,98 +159,104 @@ export interface MediaProps<BreakpointKey, Interaction> extends MediaBreakpointP
        ```
      *
      */
-    children: React.ReactNode | RenderProp;
-    /**
-     * Additional classNames to passed down and applied to Media container
-     */
-    className?: string;
-    /**
-     * Additional styles to passed down and applied to Media container
-     */
-    style?: CSSProperties;
+  children: any
+  /**
+   * Additional classNames to passed down and applied to Media container
+   */
+  className?: string
+  /**
+   * Additional styles to passed down and applied to Media container
+   */
+  style?: CSSProperties
 }
 export interface MediaContextProviderProps<M> {
-    /**
-     * This list of breakpoints and interactions can be used to limit the rendered
-     * output to these.
-     *
-     * For instance, when a server knows for some user-agents that certain
-     * breakpoints will never apply, omitting them altogether will lower the
-     * rendered byte size.
-     */
-    onlyMatch?: M[];
-    /**
-     * Disables usage of browser MediaQuery API to only render at the current
-     * breakpoint.
-     *
-     * Use this with caution, as disabling this means React components for all
-     * breakpoints will be mounted client-side and all associated life-cycle hooks
-     * will be triggered, which could lead to unintended side-effects.
-     */
-    disableDynamicMediaQueries?: boolean;
+  /**
+   * This list of breakpoints and interactions can be used to limit the rendered
+   * output to these.
+   *
+   * For instance, when a server knows for some user-agents that certain
+   * breakpoints will never apply, omitting them altogether will lower the
+   * rendered byte size.
+   */
+  onlyMatch?: M[]
+  /**
+   * Disables usage of browser MediaQuery API to only render at the current
+   * breakpoint.
+   *
+   * Use this with caution, as disabling this means React components for all
+   * breakpoints will be mounted client-side and all associated life-cycle hooks
+   * will be triggered, which could lead to unintended side-effects.
+   */
+  disableDynamicMediaQueries?: boolean
 }
 export interface CreateMediaConfig {
-    /**
-     * The breakpoint definitions for your application. Width definitions should
-     * start at 0.
-     *
-     * @see {@link createMedia}
-     */
-    breakpoints: {
-        [key: string]: number | string;
-    };
-    /**
-     * The interaction definitions for your application.
-     */
-    interactions?: {
-        [key: string]: string;
-    };
+  /**
+   * The breakpoint definitions for your application. Width definitions should
+   * start at 0.
+   *
+   * @see {@link createMedia}
+   */
+  breakpoints: {
+    [key: string]: number | string
+  }
+  /**
+   * The interaction definitions for your application.
+   */
+  interactions?: {
+    [key: string]: string
+  }
 }
 export interface CreateMediaResults<BreakpointKey, Interactions> {
-    /**
-     * The React component that you use throughout your application.
-     *
-     * @see {@link MediaBreakpointProps}
-     */
-    Media: React.ComponentType<MediaProps<BreakpointKey, Interactions>>;
-    /**
-     * The React Context provider component that you use to constrain rendering of
-     * breakpoints to a set list and to enable client-side dynamic constraining.
-     *
-     * @see {@link MediaContextProviderProps}
-     */
-    MediaContextProvider: React.ComponentType<MediaContextProviderProps<BreakpointKey | Interactions> & {
-        children: React.ReactNode;
-    }>;
-    /**
-     * Generates a set of CSS rules that you should include in your application’s
-     * styling to enable the hiding behaviour of your `Media` component uses.
-     */
-    createMediaStyle(breakpointKeys?: BreakpointConstraint[]): string;
-    /**
-     * A list of your application’s breakpoints sorted from small to large.
-     */
-    SortedBreakpoints: BreakpointKey[];
-    /**
-     * Creates a list of your application’s breakpoints that support the given
-     * widths and everything in between.
-     */
-    findBreakpointsForWidths(fromWidth: number, throughWidth: number): BreakpointKey[] | undefined;
-    /**
-     * Finds the breakpoint that matches the given width.
-     */
-    findBreakpointAtWidth(width: number): BreakpointKey | undefined;
-    /**
-     * Maps a list of values for various breakpoints to props that can be used
-     * with the `Media` component.
-     *
-     * The values map to corresponding indices in the sorted breakpoints array. If
-     * less values are specified than the number of breakpoints your application
-     * has, the last value will be applied to all subsequent breakpoints.
-     */
-    valuesWithBreakpointProps<SizeValue>(values: SizeValue[]): [SizeValue, MediaBreakpointProps<BreakpointKey>][];
+  /**
+   * The React component that you use throughout your application.
+   *
+   * @see {@link MediaBreakpointProps}
+   */
+  Media: React.ComponentType<MediaProps<BreakpointKey, Interactions>>
+  /**
+   * The React Context provider component that you use to constrain rendering of
+   * breakpoints to a set list and to enable client-side dynamic constraining.
+   *
+   * @see {@link MediaContextProviderProps}
+   */
+  MediaContextProvider: React.ComponentType<
+    MediaContextProviderProps<BreakpointKey | Interactions> & {
+      children: any
+    }
+  >
+  /**
+   * Generates a set of CSS rules that you should include in your application’s
+   * styling to enable the hiding behaviour of your `Media` component uses.
+   */
+  createMediaStyle(breakpointKeys?: BreakpointConstraint[]): string
+  /**
+   * A list of your application’s breakpoints sorted from small to large.
+   */
+  SortedBreakpoints: BreakpointKey[]
+  /**
+   * Creates a list of your application’s breakpoints that support the given
+   * widths and everything in between.
+   */
+  findBreakpointsForWidths(
+    fromWidth: number,
+    throughWidth: number
+  ): BreakpointKey[] | undefined
+  /**
+   * Finds the breakpoint that matches the given width.
+   */
+  findBreakpointAtWidth(width: number): BreakpointKey | undefined
+  /**
+   * Maps a list of values for various breakpoints to props that can be used
+   * with the `Media` component.
+   *
+   * The values map to corresponding indices in the sorted breakpoints array. If
+   * less values are specified than the number of breakpoints your application
+   * has, the last value will be applied to all subsequent breakpoints.
+   */
+  valuesWithBreakpointProps<SizeValue>(
+    values: SizeValue[]
+  ): [SizeValue, MediaBreakpointProps<BreakpointKey>][]
 }
-export type StringKeys<T> = Extract<keyof T, string>;
 /**
  * This is used to generate a Media component, its context provider, and CSS
  * rules based on your application’s breakpoints and interactions.
@@ -280,4 +287,8 @@ export type StringKeys<T> = Extract<keyof T, string>;
    ```
  *
  */
-export declare function createMedia<MediaConfig extends CreateMediaConfig, BreakpointKey extends StringKeys<keyof MediaConfig["breakpoints"]>, Interaction extends StringKeys<keyof MediaConfig["interactions"]>>(config: MediaConfig): CreateMediaResults<BreakpointKey, Interaction>;
+export declare function createMedia<
+  MediaConfig extends CreateMediaConfig,
+  BreakpointKey extends keyof MediaConfig["breakpoints"],
+  Interaction extends keyof MediaConfig["interactions"]
+>(config: MediaConfig): CreateMediaResults<BreakpointKey, Interaction>

--- a/dist/MediaQueries.d.ts
+++ b/dist/MediaQueries.d.ts
@@ -7,8 +7,8 @@ import { MediaBreakpointProps } from "./Media"
  */
 export declare class MediaQueries<B extends string> {
   static validKeys(): (
-    | BreakpointConstraint
-    | import("./Interactions").InteractionKey)[]
+    | import("./Interactions").InteractionKey
+    | BreakpointConstraint)[]
   private _breakpoints
   private _interactions
   constructor(

--- a/dist/MediaQueries.d.ts
+++ b/dist/MediaQueries.d.ts
@@ -1,24 +1,32 @@
-import { Breakpoints, BreakpointConstraint } from "./Breakpoints";
-import { MediaBreakpointProps } from "./Media";
+import { Breakpoints, BreakpointConstraint } from "./Breakpoints"
+import { MediaBreakpointProps } from "./Media"
 /**
  * Encapsulates all interaction data (and breakpoint data in the superclass)
  * needed by the Media component. The data is generated on initialization so no
  * further runtime work is necessary.
  */
 export declare class MediaQueries<B extends string> {
-    static validKeys(): (import("./Interactions").InteractionKey | BreakpointConstraint)[];
-    private _breakpoints;
-    private _interactions;
-    constructor(breakpoints: {
-        [key: string]: number;
-    }, interactions: {
-        [name: string]: string;
-    });
-    get breakpoints(): Breakpoints<B>;
-    toStyle: (breakpointKeys?: BreakpointConstraint[]) => string;
-    get mediaQueryTypes(): string[];
-    get dynamicResponsiveMediaQueries(): {};
-    shouldRenderMediaQuery(mediaQueryProps: {
-        interaction?: string;
-    } & MediaBreakpointProps, onlyMatch: string[]): boolean;
+  static validKeys(): (
+    | BreakpointConstraint
+    | import("./Interactions").InteractionKey)[]
+  private _breakpoints
+  private _interactions
+  constructor(
+    breakpoints: {
+      [key: string]: number
+    },
+    interactions: {
+      [name: string]: string
+    }
+  )
+  get breakpoints(): Breakpoints<B>
+  toStyle: (breakpointKeys?: BreakpointConstraint[]) => string
+  get mediaQueryTypes(): string[]
+  get dynamicResponsiveMediaQueries(): {}
+  shouldRenderMediaQuery(
+    mediaQueryProps: {
+      interaction?: string
+    } & MediaBreakpointProps,
+    onlyMatch: string[]
+  ): boolean
 }

--- a/dist/Utils.d.ts
+++ b/dist/Utils.d.ts
@@ -1,35 +1,43 @@
-import { MediaBreakpointProps } from "./Media";
-import { BreakpointConstraintKey } from "./Breakpoints";
+import { MediaBreakpointProps } from "./Media"
 /**
  * Extracts the single breakpoint prop from the props object.
  */
-export declare function propKey(breakpointProps: MediaBreakpointProps): BreakpointConstraintKey;
+export declare function propKey(
+  breakpointProps: MediaBreakpointProps
+): keyof MediaBreakpointProps<string>
 /**
  * Returns the intersection of two arrays.
  */
-export declare function intersection(a1: ReadonlyArray<any>, a2?: ReadonlyArray<any>): any[];
+export declare function intersection(
+  a1: ReadonlyArray<any>,
+  a2?: ReadonlyArray<any>
+): any[]
 /**
  * Generate a style rule for a given class name that will hide the element
  * when the given query matches.
  */
-export declare function createRuleSet(className: string, query: string): string;
+export declare function createRuleSet(className: string, query: string): string
 /**
  * Given a list of strings, or string tuples, generates a class name.
  */
-export declare function createClassName(...components: Array<string | [string, string]>): string;
+export declare function createClassName(
+  ...components: Array<string | [string, string]>
+): string
 /**
  * Returns an object with every values casted to integers.
  */
 export declare function castBreakpointsToIntegers(breakpoints: {
-    [key: string]: number | string;
+  [key: string]: number | string
 }): {
-    [key: string]: number;
-};
+  [key: string]: number
+}
 /**
  * Use this function to memoize any function
  */
-export declare function memoize<F extends (...args: any[]) => void>(func: F): (...args: any[]) => any;
+export declare function memoize<F extends (...args: any[]) => void>(
+  func: F
+): (...args: any[]) => any
 /**
  * Hook to determine if the current render is the first render.
  */
-export declare function useIsFirstRender(): boolean;
+export declare function useIsFirstRender(): boolean

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "tslint": "^6.1.3",
     "tslint-config-prettier": "1.15.0",
     "tslint-react": "3.6.0",
-    "typescript": "^5.6.3",
+    "typescript": "^4.9.5",
     "typescript-styled-plugin": "0.18.1",
     "webpack": "4.46.0",
     "webpack-dev-server": "4.2.1"

--- a/src/Media.tsx
+++ b/src/Media.tsx
@@ -19,10 +19,7 @@ import { BreakpointConstraint } from "./Breakpoints"
  *
  * @see {@link MediaProps.children}.
  */
-export type RenderProp = (
-  className: string,
-  renderChildren: boolean
-) => React.ReactNode
+export type RenderProp = (className: string, renderChildren: boolean) => any
 
 // TODO: All of these props should be mutually exclusive. Using a union should
 //       probably be made possible by https://github.com/Microsoft/TypeScript/pull/27408.
@@ -184,7 +181,7 @@ export interface MediaProps<BreakpointKey, Interaction>
      ```
    *
    */
-  children: React.ReactNode | RenderProp
+  children: any
 
   /**
    * Additional classNames to passed down and applied to Media container
@@ -250,7 +247,7 @@ export interface CreateMediaResults<BreakpointKey, Interactions> {
    */
   MediaContextProvider: React.ComponentType<
     MediaContextProviderProps<BreakpointKey | Interactions> & {
-      children: React.ReactNode
+      children: any
     }
   >
 
@@ -292,8 +289,6 @@ export interface CreateMediaResults<BreakpointKey, Interactions> {
   ): [SizeValue, MediaBreakpointProps<BreakpointKey>][]
 }
 
-export type StringKeys<T> = Extract<keyof T, string>
-
 /**
  * This is used to generate a Media component, its context provider, and CSS
  * rules based on your application’s breakpoints and interactions.
@@ -326,8 +321,8 @@ export type StringKeys<T> = Extract<keyof T, string>
  */
 export function createMedia<
   MediaConfig extends CreateMediaConfig,
-  BreakpointKey extends StringKeys<keyof MediaConfig["breakpoints"]>,
-  Interaction extends StringKeys<keyof MediaConfig["interactions"]>
+  BreakpointKey extends keyof MediaConfig["breakpoints"],
+  Interaction extends keyof MediaConfig["interactions"]
 >(config: MediaConfig): CreateMediaResults<BreakpointKey, Interaction> {
   const breakpoints = castBreakpointsToIntegers(config.breakpoints)
 
@@ -368,7 +363,7 @@ export function createMedia<
     children,
   }: MediaContextProviderProps<BreakpointKey | Interaction> & {
     children?: React.ReactNode
-  }): React.ReactNode => {
+  }): any => {
     if (disableDynamicMediaQueries) {
       const MediaContextValue = getMediaContextValue(onlyMatch)
 
@@ -408,9 +403,7 @@ export function createMedia<
     }
   }
 
-  const Media = (
-    props: MediaProps<BreakpointKey, Interaction>
-  ): React.ReactNode => {
+  const Media = (props: MediaProps<BreakpointKey, Interaction>): any => {
     validateProps(props)
 
     const {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "skipLibCheck": true,
     "target": "es2015",
     "strict": true,
-    "ignoreDeprecations": "5.0"
+    "ignoreDeprecations": "5.0",
+    "keyofStringsOnly": true
   },
   "exclude": ["node_modules/*", "dist", "examples/*", "src/**/__test__/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8203,10 +8203,10 @@ typescript-template-language-service-decorator@^2.2.0:
   resolved "https://registry.yarnpkg.com/typescript-template-language-service-decorator/-/typescript-template-language-service-decorator-2.2.0.tgz#4ee6d580f307fb9239978e69626f2775b8a59b2a"
   integrity sha512-xiolqt1i7e22rpqMaprPgSFVgU64u3b9n6EJlAaUYE61jumipKAdI1+O5khPlWslpTUj80YzjUKjJ2jxT0D74w==
 
-typescript@^5.6.3:
-  version "5.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.3.tgz#5f3449e31c9d94febb17de03cc081dd56d81db5b"
-  integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
+typescript@^4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 ua-parser-js@^0.7.18:
   version "0.7.33"


### PR DESCRIPTION
Fixes some more type errors around child props via `any`. Unfortunate, but out of options 🤷 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.0.1--canary.372.4962.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/fresnel@8.0.1--canary.372.4962.0
  # or 
  yarn add @artsy/fresnel@8.0.1--canary.372.4962.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
